### PR TITLE
Move inode flags inline with the inode data and add various flags

### DIFF
--- a/kernel/cfs.c
+++ b/kernel/cfs.c
@@ -100,6 +100,7 @@ static struct inode *cfs_make_inode(struct lcfs_context_s *ctx,
 	struct cfs_inode *cino;
 	struct inode *inode = NULL;
 	struct lcfs_dir_s *dirdata = NULL;
+	u8 digest_buf[LCFS_DIGEST_SIZE];
 	const uint8_t *digest;
 	int ret;
 	int r;
@@ -134,7 +135,7 @@ static struct inode *cfs_make_inode(struct lcfs_context_s *ctx,
 		ino->st_nlink = lcfs_dir_get_link_count(dirdata);
 	}
 
-	digest = lcfs_get_digest(ctx, ino);
+	digest = lcfs_get_digest(ctx, ino, real_path, digest_buf);
 
 	xattrs = lcfs_get_xattrs(ctx, ino);
 	if (IS_ERR(xattrs)) {

--- a/kernel/cfs.c
+++ b/kernel/cfs.c
@@ -134,7 +134,7 @@ static struct inode *cfs_make_inode(struct lcfs_context_s *ctx,
 		ino->st_nlink = lcfs_dir_get_link_count(dirdata);
 	}
 
-	digest = lcfs_get_digest(ctx, ino, ino_num);
+	digest = lcfs_get_digest(ctx, ino);
 
 	xattrs = lcfs_get_xattrs(ctx, ino);
 	if (IS_ERR(xattrs)) {

--- a/kernel/lcfs-reader.c
+++ b/kernel/lcfs-reader.c
@@ -259,8 +259,6 @@ struct lcfs_inode_s *lcfs_get_ino_index(struct lcfs_context_s *ctx,
 		return ERR_PTR(-EFSCORRUPTED);
 
 	ino->payload_length = lcfs_read_u32(&data);
-	ino->xattrs.off = lcfs_read_u32(&data);
-	ino->xattrs.len = lcfs_read_u32(&data);
 
 	if (LCFS_INODE_FLAG_CHECK(ino->flags, MODE)) {
 		ino->st_mode = lcfs_read_u32(&data);
@@ -312,6 +310,14 @@ struct lcfs_inode_s *lcfs_get_ino_index(struct lcfs_context_s *ctx,
 
 	if (LCFS_INODE_FLAG_CHECK(ino->flags, HIGH_SIZE)) {
 		ino->st_size += (u64)lcfs_read_u32(&data) << 32;
+	}
+
+	if (LCFS_INODE_FLAG_CHECK(ino->flags, XATTRS)) {
+		ino->xattrs.off = lcfs_read_u32(&data);
+		ino->xattrs.len = lcfs_read_u32(&data);
+	} else {
+		ino->xattrs.off = 0;
+		ino->xattrs.len = 0;
 	}
 
 	if (LCFS_INODE_FLAG_CHECK(ino->flags, DIGEST)) {

--- a/kernel/lcfs-reader.c
+++ b/kernel/lcfs-reader.c
@@ -342,10 +342,15 @@ struct lcfs_inode_s *lcfs_get_root_ino(struct lcfs_context_s *ctx,
 	return lcfs_get_ino_index(ctx, root_ino, ino_buf);
 }
 
-const uint8_t *lcfs_get_digest(struct lcfs_context_s *ctx, struct lcfs_inode_s *ino)
+const uint8_t *lcfs_get_digest(struct lcfs_context_s *ctx, struct lcfs_inode_s *ino, const char *payload, u8 digest_buf[LCFS_DIGEST_SIZE])
 {
 	if (LCFS_INODE_FLAG_CHECK(ino->flags, DIGEST)) {
 		return ino->digest;
+	}
+
+	if (LCFS_INODE_FLAG_CHECK(ino->flags, DIGEST_FROM_PAYLOAD && payload != NULL)) {
+		if (lcfs_digest_from_payload(payload, ino->payload_length, digest_buf) == 0)
+			return digest_buf;
 	}
 
 	return NULL;

--- a/kernel/lcfs-reader.c
+++ b/kernel/lcfs-reader.c
@@ -258,7 +258,11 @@ struct lcfs_inode_s *lcfs_get_ino_index(struct lcfs_context_s *ctx,
 	if (inode_size > sizeof(buffer))
 		return ERR_PTR(-EFSCORRUPTED);
 
-	ino->payload_length = lcfs_read_u32(&data);
+	if (LCFS_INODE_FLAG_CHECK(ino->flags, PAYLOAD)) {
+		ino->payload_length = lcfs_read_u32(&data);
+	} else {
+		ino->payload_length = 0;
+	}
 
 	if (LCFS_INODE_FLAG_CHECK(ino->flags, MODE)) {
 		ino->st_mode = lcfs_read_u32(&data);

--- a/kernel/lcfs-reader.h
+++ b/kernel/lcfs-reader.h
@@ -32,7 +32,7 @@ static inline u64 lcfs_dentry_ino(struct lcfs_dentry_s *d)
 	return d->inode_index;
 }
 
-const uint8_t *lcfs_get_digest(struct lcfs_context_s *ctx, struct lcfs_inode_s *ino);
+const uint8_t *lcfs_get_digest(struct lcfs_context_s *ctx, struct lcfs_inode_s *ino, const char *payload, u8 digest_buf[LCFS_DIGEST_SIZE]);
 
 struct lcfs_dir_s *lcfs_get_dir(struct lcfs_context_s *ctx, struct lcfs_inode_s *ino, lcfs_off_t index);
 

--- a/kernel/lcfs-reader.h
+++ b/kernel/lcfs-reader.h
@@ -32,7 +32,7 @@ static inline u64 lcfs_dentry_ino(struct lcfs_dentry_s *d)
 	return d->inode_index;
 }
 
-const uint8_t *lcfs_get_digest(struct lcfs_context_s *ctx, struct lcfs_inode_s *ino, lcfs_off_t index);
+const uint8_t *lcfs_get_digest(struct lcfs_context_s *ctx, struct lcfs_inode_s *ino);
 
 struct lcfs_dir_s *lcfs_get_dir(struct lcfs_context_s *ctx, struct lcfs_inode_s *ino, lcfs_off_t index);
 

--- a/kernel/lcfs.h
+++ b/kernel/lcfs.h
@@ -95,12 +95,12 @@ struct lcfs_vdata_s {
 struct lcfs_header_s {
 	u8 version;
 	u8 unused1;
-	uint16_t root_flags;  /* flags of root inode */
+	uint16_t unused2;
 
 	u32 inode_len;
 	lcfs_off_t data_offset;
 
-	u64 unused2[3];
+	u64 unused3[3];
 } __attribute__((packed));
 
 enum lcfs_inode_flags {
@@ -119,11 +119,6 @@ enum lcfs_inode_flags {
 #define LCFS_INODE_FLAG_CHECK(_flag, _name) (((_flag) & (LCFS_INODE_FLAGS_ ## _name)) != 0)
 #define LCFS_INODE_FLAG_CHECK_SIZE(_flag, _name, _size) (LCFS_INODE_FLAG_CHECK(_flag, _name) ? (_size) : 0)
 
-#define LCFS_INODE_INDEX_SHIFT 9
-#define	LCFS_INODE_FLAGS_MASK ((1 << LCFS_INODE_INDEX_SHIFT) - 1)
-#define LCFS_MAKE_INO(_index, _flags) ((u64)(_flags) | (((u64)(_index)) << LCFS_INODE_INDEX_SHIFT))
-
-
 #define LCFS_INODE_DEFAULT_MODE 0100644
 #define LCFS_INODE_DEFAULT_NLINK 1
 #define LCFS_INODE_DEFAULT_UIDGID 0
@@ -131,6 +126,7 @@ enum lcfs_inode_flags {
 #define LCFS_INODE_DEFAULT_TIMES 0
 
 struct lcfs_inode_s {
+	u32 flags;
 	/* This is the size of the type specific data that comes directly after
 	   the inode in the file. Of this type:
 	   *
@@ -161,6 +157,7 @@ struct lcfs_inode_s {
 static inline u32 lcfs_inode_encoded_size(u32 flags)
 {
 	return
+		sizeof(u32) /* flags */ +
 		sizeof(u32) /* payload_length */ +
 		sizeof(struct lcfs_vdata_s) /* xattrs */ +
 		LCFS_INODE_FLAG_CHECK_SIZE(flags, MODE, sizeof(u32)) +

--- a/kernel/lcfs.h
+++ b/kernel/lcfs.h
@@ -113,7 +113,8 @@ enum lcfs_inode_flags {
 	LCFS_INODE_FLAGS_TIMES_NSEC      = 1 << 5,
 	LCFS_INODE_FLAGS_LOW_SIZE        = 1 << 6, /* Low 32bit of st_size */
 	LCFS_INODE_FLAGS_HIGH_SIZE       = 1 << 7, /* High 32bit of st_size */
-	LCFS_INODE_FLAGS_DIGEST          = 1 << 8, /* fs-verity sha256 digest of content */
+	LCFS_INODE_FLAGS_XATTRS          = 1 << 8,
+	LCFS_INODE_FLAGS_DIGEST          = 1 << 9, /* fs-verity sha256 digest of content */
 };
 
 #define LCFS_INODE_FLAG_CHECK(_flag, _name) (((_flag) & (LCFS_INODE_FLAGS_ ## _name)) != 0)
@@ -138,16 +139,17 @@ struct lcfs_inode_s {
 	   */
 	u32 payload_length;
 
-	/* Variable len data.  */
-	struct lcfs_vdata_s xattrs;
-
 	/* Optional data: (selected by flags) */
+
 	u32 st_mode; /* File type and mode.  */
 	u32 st_nlink; /* Number of hard links, only for regular files.  */
 	u32 st_uid; /* User ID of owner.  */
 	u32 st_gid; /* Group ID of owner.  */
 	u32 st_rdev; /* Device ID (if special file).  */
 	u64 st_size; /* Size of file, only used for regular files */
+
+	struct lcfs_vdata_s xattrs; /* ref to variable data */
+
 	uint8_t digest[LCFS_DIGEST_SIZE]; /* sha256 fs-verity digest */
 
 	struct timespec64 st_mtim; /* Time of last modification.  */
@@ -159,7 +161,6 @@ static inline u32 lcfs_inode_encoded_size(u32 flags)
 	return
 		sizeof(u32) /* flags */ +
 		sizeof(u32) /* payload_length */ +
-		sizeof(struct lcfs_vdata_s) /* xattrs */ +
 		LCFS_INODE_FLAG_CHECK_SIZE(flags, MODE, sizeof(u32)) +
 		LCFS_INODE_FLAG_CHECK_SIZE(flags, NLINK, sizeof(u32)) +
 		LCFS_INODE_FLAG_CHECK_SIZE(flags, UIDGID, sizeof(u32) + sizeof(u32)) +
@@ -168,6 +169,7 @@ static inline u32 lcfs_inode_encoded_size(u32 flags)
 		LCFS_INODE_FLAG_CHECK_SIZE(flags, TIMES_NSEC, sizeof(u32)*2) +
 		LCFS_INODE_FLAG_CHECK_SIZE(flags, LOW_SIZE, sizeof(u32)) +
 		LCFS_INODE_FLAG_CHECK_SIZE(flags, HIGH_SIZE, sizeof(u32)) +
+		LCFS_INODE_FLAG_CHECK_SIZE(flags, XATTRS, sizeof(uint32_t)*2) +
 		LCFS_INODE_FLAG_CHECK_SIZE(flags, DIGEST, LCFS_DIGEST_SIZE)
 		;
 }

--- a/kernel/lcfs.h
+++ b/kernel/lcfs.h
@@ -105,16 +105,17 @@ struct lcfs_header_s {
 
 enum lcfs_inode_flags {
 	LCFS_INODE_FLAGS_NONE            = 0,
-	LCFS_INODE_FLAGS_MODE            = 1 << 0,
-	LCFS_INODE_FLAGS_NLINK           = 1 << 1,
-	LCFS_INODE_FLAGS_UIDGID          = 1 << 2,
-	LCFS_INODE_FLAGS_RDEV            = 1 << 3,
-	LCFS_INODE_FLAGS_TIMES           = 1 << 4,
-	LCFS_INODE_FLAGS_TIMES_NSEC      = 1 << 5,
-	LCFS_INODE_FLAGS_LOW_SIZE        = 1 << 6, /* Low 32bit of st_size */
-	LCFS_INODE_FLAGS_HIGH_SIZE       = 1 << 7, /* High 32bit of st_size */
-	LCFS_INODE_FLAGS_XATTRS          = 1 << 8,
-	LCFS_INODE_FLAGS_DIGEST          = 1 << 9, /* fs-verity sha256 digest of content */
+	LCFS_INODE_FLAGS_PAYLOAD         = 1 << 0,
+	LCFS_INODE_FLAGS_MODE            = 1 << 1,
+	LCFS_INODE_FLAGS_NLINK           = 1 << 2,
+	LCFS_INODE_FLAGS_UIDGID          = 1 << 3,
+	LCFS_INODE_FLAGS_RDEV            = 1 << 4,
+	LCFS_INODE_FLAGS_TIMES           = 1 << 5,
+	LCFS_INODE_FLAGS_TIMES_NSEC      = 1 << 6,
+	LCFS_INODE_FLAGS_LOW_SIZE        = 1 << 7, /* Low 32bit of st_size */
+	LCFS_INODE_FLAGS_HIGH_SIZE       = 1 << 8, /* High 32bit of st_size */
+	LCFS_INODE_FLAGS_XATTRS          = 1 << 9,
+	LCFS_INODE_FLAGS_DIGEST          = 1 << 10, /* fs-verity sha256 digest of content */
 };
 
 #define LCFS_INODE_FLAG_CHECK(_flag, _name) (((_flag) & (LCFS_INODE_FLAGS_ ## _name)) != 0)
@@ -128,6 +129,9 @@ enum lcfs_inode_flags {
 
 struct lcfs_inode_s {
 	u32 flags;
+
+	/* Optional data: (selected by flags) */
+
 	/* This is the size of the type specific data that comes directly after
 	   the inode in the file. Of this type:
 	   *
@@ -138,8 +142,6 @@ struct lcfs_inode_s {
 	   * Canonically payload_length is 0 for empty dir/file/symlink.
 	   */
 	u32 payload_length;
-
-	/* Optional data: (selected by flags) */
 
 	u32 st_mode; /* File type and mode.  */
 	u32 st_nlink; /* Number of hard links, only for regular files.  */
@@ -160,7 +162,7 @@ static inline u32 lcfs_inode_encoded_size(u32 flags)
 {
 	return
 		sizeof(u32) /* flags */ +
-		sizeof(u32) /* payload_length */ +
+		LCFS_INODE_FLAG_CHECK_SIZE(flags, PAYLOAD, sizeof(u32)) +
 		LCFS_INODE_FLAG_CHECK_SIZE(flags, MODE, sizeof(u32)) +
 		LCFS_INODE_FLAG_CHECK_SIZE(flags, NLINK, sizeof(u32)) +
 		LCFS_INODE_FLAG_CHECK_SIZE(flags, UIDGID, sizeof(u32) + sizeof(u32)) +

--- a/tools/dump.c
+++ b/tools/dump.c
@@ -76,7 +76,12 @@ static void decode_inode(const uint8_t *inode_data, lcfs_off_t inod_num, struct 
 	memset(ino, 0, sizeof(struct lcfs_inode_s));
 
 	ino->flags = decode_uint32(&data);
-	ino->payload_length = decode_uint32(&data);
+
+	if (LCFS_INODE_FLAG_CHECK(ino->flags, PAYLOAD)) {
+		ino->payload_length = decode_uint32(&data);
+	} else {
+		ino->payload_length = 0;
+	}
 
 	if (LCFS_INODE_FLAG_CHECK(ino->flags, MODE)) {
 		ino->st_mode = decode_uint32(&data);

--- a/tools/dump.c
+++ b/tools/dump.c
@@ -69,28 +69,30 @@ static uint64_t decode_uint64(const uint8_t **data) {
 	return lcfs_u64_from_file(*d);
 }
 
-static void decode_inode(const uint8_t *inode_data, lcfs_off_t inod_num, struct lcfs_inode_s *ino, uint32_t *flags_out, const uint8_t **payload_data_out)
+static void decode_inode(const uint8_t *inode_data, lcfs_off_t inod_num, struct lcfs_inode_s *ino, const uint8_t **payload_data_out)
 {
-	uint32_t flags = inod_num & LCFS_INODE_FLAGS_MASK;
-	const uint8_t *data = inode_data + (inod_num >> LCFS_INODE_INDEX_SHIFT);
+	const uint8_t *data = inode_data + inod_num;
 
+	memset(ino, 0, sizeof(struct lcfs_inode_s));
+
+	ino->flags = decode_uint32(&data);
 	ino->payload_length = decode_uint32(&data);
 	ino->xattrs.off = decode_uint32(&data);
 	ino->xattrs.len = decode_uint32(&data);
 
-	if (LCFS_INODE_FLAG_CHECK(flags, MODE)) {
+	if (LCFS_INODE_FLAG_CHECK(ino->flags, MODE)) {
 		ino->st_mode = decode_uint32(&data);
 	} else {
 		ino->st_mode = LCFS_INODE_DEFAULT_MODE;
 	}
 
-	if (LCFS_INODE_FLAG_CHECK(flags, NLINK)) {
+	if (LCFS_INODE_FLAG_CHECK(ino->flags, NLINK)) {
 		ino->st_nlink = decode_uint32(&data);
 	} else {
 		ino->st_nlink = LCFS_INODE_DEFAULT_NLINK;
 	}
 
-	if (LCFS_INODE_FLAG_CHECK(flags, UIDGID)) {
+	if (LCFS_INODE_FLAG_CHECK(ino->flags, UIDGID)) {
 		ino->st_uid = decode_uint32(&data);
 		ino->st_gid = decode_uint32(&data);
 	} else {
@@ -98,13 +100,13 @@ static void decode_inode(const uint8_t *inode_data, lcfs_off_t inod_num, struct 
 		ino->st_gid = LCFS_INODE_DEFAULT_UIDGID;
 	}
 
-	if (LCFS_INODE_FLAG_CHECK(flags, RDEV)) {
+	if (LCFS_INODE_FLAG_CHECK(ino->flags, RDEV)) {
 		ino->st_rdev = decode_uint32(&data);
 	} else {
 		ino->st_rdev = LCFS_INODE_DEFAULT_RDEV;
 	}
 
-	if (LCFS_INODE_FLAG_CHECK(flags, TIMES)) {
+	if (LCFS_INODE_FLAG_CHECK(ino->flags, TIMES)) {
 		ino->st_mtim.tv_sec = decode_uint64(&data);
 		ino->st_ctim.tv_sec = decode_uint64(&data);
 	} else {
@@ -112,7 +114,7 @@ static void decode_inode(const uint8_t *inode_data, lcfs_off_t inod_num, struct 
 		ino->st_ctim.tv_sec = LCFS_INODE_DEFAULT_TIMES;
 	}
 
-	if (LCFS_INODE_FLAG_CHECK(flags, TIMES_NSEC)) {
+	if (LCFS_INODE_FLAG_CHECK(ino->flags, TIMES_NSEC)) {
 		ino->st_mtim.tv_nsec = decode_uint32(&data);
 		ino->st_ctim.tv_nsec = decode_uint32(&data);
 	} else {
@@ -120,23 +122,22 @@ static void decode_inode(const uint8_t *inode_data, lcfs_off_t inod_num, struct 
 		ino->st_ctim.tv_nsec = 0;
 	}
 
-	if (LCFS_INODE_FLAG_CHECK(flags, LOW_SIZE)) {
+	if (LCFS_INODE_FLAG_CHECK(ino->flags, LOW_SIZE)) {
 		ino->st_size = decode_uint32(&data);
 	} else {
 		ino->st_size = 0;
 	}
 
-	if (LCFS_INODE_FLAG_CHECK(flags, HIGH_SIZE)) {
+	if (LCFS_INODE_FLAG_CHECK(ino->flags, HIGH_SIZE)) {
 		ino->st_size += (uint64_t)decode_uint32(&data) << 32;
 	}
 
-	if (LCFS_INODE_FLAG_CHECK(flags, DIGEST)) {
+	if (LCFS_INODE_FLAG_CHECK(ino->flags, DIGEST)) {
 		memcpy(ino->digest, data, LCFS_DIGEST_SIZE);
 		data += LCFS_DIGEST_SIZE;
 	}
 
-	*flags_out = flags;
-	*payload_data_out = inode_data + (inod_num >> LCFS_INODE_INDEX_SHIFT) + lcfs_inode_encoded_size(flags);
+	*payload_data_out = inode_data + inod_num + lcfs_inode_encoded_size(ino->flags);
 
 }
 
@@ -150,7 +151,7 @@ static void digest_to_string(const uint8_t *csum, char *buf)
 		buf[j] = hexchars[byte >> 4];
 		buf[j+1] = hexchars[byte & 0xF];
 	}
-  buf[j] = '\0';
+	buf[j] = '\0';
 }
 
 static int dump_inode(const uint8_t *inode_data, const uint8_t *vdata, const char *name, size_t name_len, lcfs_off_t index,
@@ -158,11 +159,10 @@ static int dump_inode(const uint8_t *inode_data, const uint8_t *vdata, const cha
 {
 	struct lcfs_inode_s ino;
 	const uint8_t *payload_data;
-	uint32_t flags;
 	bool dirp;
 	size_t i;
 
-	decode_inode(inode_data, index, &ino, &flags, &payload_data);
+	decode_inode(inode_data, index, &ino, &payload_data);
 
 	dirp = is_dir(&ino);
 
@@ -209,7 +209,7 @@ static int dump_inode(const uint8_t *inode_data, const uint8_t *vdata, const cha
 			n_xattrs = lcfs_u16_from_file(header->n_attr);
 		}
 
-		if (flags & LCFS_INODE_FLAGS_DIGEST) {
+		if (ino.flags & LCFS_INODE_FLAGS_DIGEST) {
 			digest_to_string(ino.digest, digest_str);
 		}
 
@@ -247,12 +247,11 @@ static lcfs_off_t find_child(const uint8_t *inode_data, lcfs_off_t current, cons
 {
 	struct lcfs_inode_s ino;
 	const uint8_t *payload_data;
-	uint32_t flags;
 	const char *namedata;
 	const struct lcfs_dir_s *dir;
 	size_t i, n_dentries, name_len;
 
-	decode_inode(inode_data, current, &ino, &flags, &payload_data);
+	decode_inode(inode_data, current, &ino, &payload_data);
 
 	if (!is_dir(&ino))
 		return UINT64_MAX;
@@ -363,7 +362,7 @@ int main(int argc, char *argv[])
 
 	inode_data = data + sizeof(struct lcfs_header_s);
 	vdata = data + lcfs_u64_from_file(header->data_offset);
-	root_index = LCFS_MAKE_INO(0, lcfs_u16_from_file(header->root_flags));
+	root_index = 0;
 	if (mode == DUMP) {
 		dump_inode(inode_data, vdata, "", 0, root_index, 0, false, false, true);
 	} else if (mode == DUMP_EXTENDED) {

--- a/tools/dump.c
+++ b/tools/dump.c
@@ -77,8 +77,6 @@ static void decode_inode(const uint8_t *inode_data, lcfs_off_t inod_num, struct 
 
 	ino->flags = decode_uint32(&data);
 	ino->payload_length = decode_uint32(&data);
-	ino->xattrs.off = decode_uint32(&data);
-	ino->xattrs.len = decode_uint32(&data);
 
 	if (LCFS_INODE_FLAG_CHECK(ino->flags, MODE)) {
 		ino->st_mode = decode_uint32(&data);
@@ -130,6 +128,14 @@ static void decode_inode(const uint8_t *inode_data, lcfs_off_t inod_num, struct 
 
 	if (LCFS_INODE_FLAG_CHECK(ino->flags, HIGH_SIZE)) {
 		ino->st_size += (uint64_t)decode_uint32(&data) << 32;
+	}
+
+	if (LCFS_INODE_FLAG_CHECK(ino->flags, XATTRS)) {
+		ino->xattrs.off = decode_uint32(&data);
+		ino->xattrs.len = decode_uint32(&data);
+	} else {
+		ino->xattrs.off = 0;
+		ino->xattrs.len = 0;
 	}
 
 	if (LCFS_INODE_FLAG_CHECK(ino->flags, DIGEST)) {

--- a/tools/lcfs/lcfs-writer.c
+++ b/tools/lcfs/lcfs-writer.c
@@ -335,8 +335,14 @@ static uint32_t compute_flags(struct lcfs_node_s *node) {
 		flags |= LCFS_INODE_FLAGS_HIGH_SIZE;
 	if (node->n_xattrs > 0)
 		flags |= LCFS_INODE_FLAGS_XATTRS;
-	if (node->digest_set)
-		flags |= LCFS_INODE_FLAGS_DIGEST;
+	if (node->digest_set) {
+		uint8_t payload_digest[LCFS_DIGEST_SIZE];
+		if (lcfs_digest_from_payload(node->payload, node->inode.payload_length, payload_digest) == 0 &&
+		    memcmp(payload_digest, node->inode.digest, LCFS_DIGEST_SIZE) == 0)
+			flags |= LCFS_INODE_FLAGS_DIGEST_FROM_PAYLOAD;
+		else
+			flags |= LCFS_INODE_FLAGS_DIGEST;
+	}
 
 	return flags;
 }

--- a/tools/lcfs/lcfs.h
+++ b/tools/lcfs/lcfs.h
@@ -74,16 +74,17 @@ struct lcfs_header_s {
 
 enum lcfs_inode_flags {
 	LCFS_INODE_FLAGS_NONE            = 0,
-	LCFS_INODE_FLAGS_MODE            = 1 << 0,
-	LCFS_INODE_FLAGS_NLINK           = 1 << 1,
-	LCFS_INODE_FLAGS_UIDGID          = 1 << 2,
-	LCFS_INODE_FLAGS_RDEV            = 1 << 3,
-	LCFS_INODE_FLAGS_TIMES           = 1 << 4,
-	LCFS_INODE_FLAGS_TIMES_NSEC      = 1 << 5,
-	LCFS_INODE_FLAGS_LOW_SIZE        = 1 << 6, /* Low 32bit of st_size */
-	LCFS_INODE_FLAGS_HIGH_SIZE       = 1 << 7, /* High 32bit of st_size */
-	LCFS_INODE_FLAGS_XATTRS          = 1 << 8,
-	LCFS_INODE_FLAGS_DIGEST          = 1 << 9, /* fs-verity sha256 digest of content */
+	LCFS_INODE_FLAGS_PAYLOAD         = 1 << 0,
+	LCFS_INODE_FLAGS_MODE            = 1 << 1,
+	LCFS_INODE_FLAGS_NLINK           = 1 << 2,
+	LCFS_INODE_FLAGS_UIDGID          = 1 << 3,
+	LCFS_INODE_FLAGS_RDEV            = 1 << 4,
+	LCFS_INODE_FLAGS_TIMES           = 1 << 5,
+	LCFS_INODE_FLAGS_TIMES_NSEC      = 1 << 6,
+	LCFS_INODE_FLAGS_LOW_SIZE        = 1 << 7, /* Low 32bit of st_size */
+	LCFS_INODE_FLAGS_HIGH_SIZE       = 1 << 8, /* High 32bit of st_size */
+	LCFS_INODE_FLAGS_XATTRS          = 1 << 9,
+	LCFS_INODE_FLAGS_DIGEST          = 1 << 10, /* fs-verity sha256 digest of content */
 };
 
 #define LCFS_INODE_FLAG_CHECK(_flag, _name) (((_flag) & (LCFS_INODE_FLAGS_ ## _name)) != 0)
@@ -97,6 +98,9 @@ enum lcfs_inode_flags {
 
 struct lcfs_inode_s {
 	uint32_t flags;
+
+	/* Optional data: (selected by flags) */
+
 	/* This is the size of the type specific data that comes directly after
 	   the inode in the file. Of this type:
 	   *
@@ -107,8 +111,6 @@ struct lcfs_inode_s {
 	   * Canonically payload_length is 0 for empty dir/file/symlink
 	   */
 	uint32_t payload_length;
-
-	/* Optional data: (selected by flags) */
 
 	uint32_t st_mode; /* File type and mode.  */
 	uint32_t st_nlink; /* Number of hard links, only for regular files.  */
@@ -129,7 +131,7 @@ static inline uint32_t lcfs_inode_encoded_size(uint32_t flags)
 {
 	return
 		sizeof(uint32_t) /* flags */ +
-		sizeof(uint32_t) /* payload_length */ +
+		LCFS_INODE_FLAG_CHECK_SIZE(flags, PAYLOAD, sizeof(uint32_t)) +
 		LCFS_INODE_FLAG_CHECK_SIZE(flags, MODE, sizeof(uint32_t)) +
 		LCFS_INODE_FLAG_CHECK_SIZE(flags, NLINK, sizeof(uint32_t)) +
 		LCFS_INODE_FLAG_CHECK_SIZE(flags, UIDGID, sizeof(uint32_t) + sizeof(uint32_t)) +

--- a/tools/lcfs/lcfs.h
+++ b/tools/lcfs/lcfs.h
@@ -63,12 +63,12 @@ struct lcfs_vdata_s {
 struct lcfs_header_s {
 	uint8_t version;
 	uint8_t unused1;
-	uint16_t root_flags;  /* flags of root inode */
+	uint16_t unused2;
 
 	uint32_t inode_len;
 	lcfs_off_t data_offset;
 
-	uint64_t unused2[3];
+	uint64_t unused3[3];
 } __attribute__((packed));
 
 
@@ -88,10 +88,6 @@ enum lcfs_inode_flags {
 #define LCFS_INODE_FLAG_CHECK(_flag, _name) (((_flag) & (LCFS_INODE_FLAGS_ ## _name)) != 0)
 #define LCFS_INODE_FLAG_CHECK_SIZE(_flag, _name, _size) (LCFS_INODE_FLAG_CHECK(_flag, _name) ? (_size) : 0)
 
-#define LCFS_INODE_INDEX_SHIFT 9
-#define	LCFS_INODE_FLAGS_MASK ((1 << LCFS_INODE_INDEX_SHIFT) - 1)
-#define LCFS_MAKE_INO(_index, _flags) ((uint64_t)(_flags) | (((uint64_t)(_index)) << LCFS_INODE_INDEX_SHIFT))
-
 #define LCFS_INODE_DEFAULT_MODE 0100644
 #define LCFS_INODE_DEFAULT_NLINK 1
 #define LCFS_INODE_DEFAULT_UIDGID 0
@@ -99,6 +95,7 @@ enum lcfs_inode_flags {
 #define LCFS_INODE_DEFAULT_TIMES 0
 
 struct lcfs_inode_s {
+	uint32_t flags;
 	/* This is the size of the type specific data that comes directly after
 	   the inode in the file. Of this type:
 	   *
@@ -129,6 +126,7 @@ struct lcfs_inode_s {
 static inline uint32_t lcfs_inode_encoded_size(uint32_t flags)
 {
 	return
+		sizeof(uint32_t) /* flags */ +
 		sizeof(uint32_t) /* payload_length */ +
 		sizeof(struct lcfs_vdata_s) /* xattrs */ +
 		LCFS_INODE_FLAG_CHECK_SIZE(flags, MODE, sizeof(uint32_t)) +

--- a/tools/lcfs/lcfs.h
+++ b/tools/lcfs/lcfs.h
@@ -55,6 +55,54 @@ static inline uint64_t lcfs_u64_from_file(uint64_t val) {
 	return le64toh(val);
 }
 
+static inline int lcfs_xdigit_value (char c)
+{
+  if (c >= '0' && c <= '9')
+    return c - '0';
+  if (c >= 'A' && c <= 'F')
+    return c - 'A' + 10;
+  if (c >= 'a' && c <= 'f')
+    return c - 'a' + 10;
+  return -1;
+}
+
+static inline int lcfs_digest_from_payload(const char *payload, size_t payload_len, uint8_t digest_out[LCFS_DIGEST_SIZE])
+{
+	const char *p, *end;
+	uint8_t last_digit = 0, digit = 0;
+	size_t n_nibbles = 0;
+
+	end = payload + payload_len;
+	for (p = payload; p != end; p++) {
+		/* Skip subdir structure */
+		if (*p == '/')
+			continue;
+
+		/* Break at (and ignore) extension */
+		if (*p == '.')
+			break;
+
+		if (n_nibbles == LCFS_DIGEST_SIZE * 2)
+			return -1; /* Too long */
+
+		digit = lcfs_xdigit_value(*p);
+		if (digit == -1) {
+			return -1; /* Not hex digit */
+		}
+
+		n_nibbles++;
+		if ((n_nibbles % 2) == 0) {
+			digest_out[n_nibbles/2 - 1] = (last_digit << 4) | digit;
+		}
+		last_digit = digit;
+	}
+
+	if (n_nibbles != LCFS_DIGEST_SIZE * 2)
+		return -1; /* Too short */
+
+	return 0;
+}
+
 struct lcfs_vdata_s {
 	uint32_t off;
 	uint32_t len;
@@ -73,18 +121,19 @@ struct lcfs_header_s {
 
 
 enum lcfs_inode_flags {
-	LCFS_INODE_FLAGS_NONE            = 0,
-	LCFS_INODE_FLAGS_PAYLOAD         = 1 << 0,
-	LCFS_INODE_FLAGS_MODE            = 1 << 1,
-	LCFS_INODE_FLAGS_NLINK           = 1 << 2,
-	LCFS_INODE_FLAGS_UIDGID          = 1 << 3,
-	LCFS_INODE_FLAGS_RDEV            = 1 << 4,
-	LCFS_INODE_FLAGS_TIMES           = 1 << 5,
-	LCFS_INODE_FLAGS_TIMES_NSEC      = 1 << 6,
-	LCFS_INODE_FLAGS_LOW_SIZE        = 1 << 7, /* Low 32bit of st_size */
-	LCFS_INODE_FLAGS_HIGH_SIZE       = 1 << 8, /* High 32bit of st_size */
-	LCFS_INODE_FLAGS_XATTRS          = 1 << 9,
-	LCFS_INODE_FLAGS_DIGEST          = 1 << 10, /* fs-verity sha256 digest of content */
+	LCFS_INODE_FLAGS_NONE                = 0,
+	LCFS_INODE_FLAGS_PAYLOAD             = 1 << 0,
+	LCFS_INODE_FLAGS_MODE                = 1 << 1,
+	LCFS_INODE_FLAGS_NLINK               = 1 << 2,
+	LCFS_INODE_FLAGS_UIDGID              = 1 << 3,
+	LCFS_INODE_FLAGS_RDEV                = 1 << 4,
+	LCFS_INODE_FLAGS_TIMES               = 1 << 5,
+	LCFS_INODE_FLAGS_TIMES_NSEC          = 1 << 6,
+	LCFS_INODE_FLAGS_LOW_SIZE            = 1 << 7, /* Low 32bit of st_size */
+	LCFS_INODE_FLAGS_HIGH_SIZE           = 1 << 8, /* High 32bit of st_size */
+	LCFS_INODE_FLAGS_XATTRS              = 1 << 9,
+	LCFS_INODE_FLAGS_DIGEST              = 1 << 10, /* fs-verity sha256 digest of content */
+	LCFS_INODE_FLAGS_DIGEST_FROM_PAYLOAD = 1 << 11, /* Compute digest from payload */
 };
 
 #define LCFS_INODE_FLAG_CHECK(_flag, _name) (((_flag) & (LCFS_INODE_FLAGS_ ## _name)) != 0)

--- a/tools/lcfs/lcfs.h
+++ b/tools/lcfs/lcfs.h
@@ -82,7 +82,8 @@ enum lcfs_inode_flags {
 	LCFS_INODE_FLAGS_TIMES_NSEC      = 1 << 5,
 	LCFS_INODE_FLAGS_LOW_SIZE        = 1 << 6, /* Low 32bit of st_size */
 	LCFS_INODE_FLAGS_HIGH_SIZE       = 1 << 7, /* High 32bit of st_size */
-	LCFS_INODE_FLAGS_DIGEST          = 1 << 8, /* fs-verity sha256 digest of content */
+	LCFS_INODE_FLAGS_XATTRS          = 1 << 8,
+	LCFS_INODE_FLAGS_DIGEST          = 1 << 9, /* fs-verity sha256 digest of content */
 };
 
 #define LCFS_INODE_FLAG_CHECK(_flag, _name) (((_flag) & (LCFS_INODE_FLAGS_ ## _name)) != 0)
@@ -107,16 +108,17 @@ struct lcfs_inode_s {
 	   */
 	uint32_t payload_length;
 
-	/* Variable len data.  */
-	struct lcfs_vdata_s xattrs;
-
 	/* Optional data: (selected by flags) */
+
 	uint32_t st_mode; /* File type and mode.  */
 	uint32_t st_nlink; /* Number of hard links, only for regular files.  */
 	uint32_t st_uid; /* User ID of owner.  */
 	uint32_t st_gid; /* Group ID of owner.  */
 	uint32_t st_rdev; /* Device ID (if special file).  */
 	uint64_t st_size; /* Size of file, only used for regular files */
+
+	struct lcfs_vdata_s xattrs; /* ref to variable data */
+
 	uint8_t digest[LCFS_DIGEST_SIZE]; /* sha256 fs-verity digest */
 
 	struct timespec st_mtim; /* Time of last modification.  */
@@ -128,7 +130,6 @@ static inline uint32_t lcfs_inode_encoded_size(uint32_t flags)
 	return
 		sizeof(uint32_t) /* flags */ +
 		sizeof(uint32_t) /* payload_length */ +
-		sizeof(struct lcfs_vdata_s) /* xattrs */ +
 		LCFS_INODE_FLAG_CHECK_SIZE(flags, MODE, sizeof(uint32_t)) +
 		LCFS_INODE_FLAG_CHECK_SIZE(flags, NLINK, sizeof(uint32_t)) +
 		LCFS_INODE_FLAG_CHECK_SIZE(flags, UIDGID, sizeof(uint32_t) + sizeof(uint32_t)) +
@@ -137,6 +138,7 @@ static inline uint32_t lcfs_inode_encoded_size(uint32_t flags)
 		LCFS_INODE_FLAG_CHECK_SIZE(flags, TIMES_NSEC, sizeof(uint32_t)*2) +
 		LCFS_INODE_FLAG_CHECK_SIZE(flags, LOW_SIZE, sizeof(uint32_t)) +
 		LCFS_INODE_FLAG_CHECK_SIZE(flags, HIGH_SIZE, sizeof(uint32_t)) +
+		LCFS_INODE_FLAG_CHECK_SIZE(flags, XATTRS, sizeof(uint32_t)*2) +
 		LCFS_INODE_FLAG_CHECK_SIZE(flags, DIGEST, LCFS_DIGEST_SIZE)
 		;
 }


### PR DESCRIPTION
This makes the inode nr handling simple (its just the offset from the header), and it make the flags more flexible.

Since we now have more space for flags we can also add stuff, like for payloads and xattrs making these save space when missing. We also add a DIGEST_FROM_PAYLOAD flag that avoids storing the digest separately if it is encoded in the payload anyway.