### PR TITLE
Use a better magic value and embed it in the descriptor header

### DIFF
--- a/kernel/cfs.c
+++ b/kernel/cfs.c
@@ -39,8 +39,6 @@ MODULE_AUTHOR("Giuseppe Scrivano <gscrivan@redhat.com>");
 
 #include "lcfs-verity.h"
 
-#define CFS_MAGIC 0x12345678
-
 struct cfs_info {
 	struct lcfs_context_s *lcfs_ctx;
 
@@ -507,7 +505,7 @@ static int cfs_fill_super(struct super_block *sb, struct fs_context *fc)
 	/* Set up the inode allocator early */
 	sb->s_op = &cfs_ops;
 	sb->s_flags |= SB_RDONLY;
-	sb->s_magic = CFS_MAGIC;
+	sb->s_magic = LCFS_MAGIC;
 	sb->s_xattr = cfs_xattr_handlers;
 	sb->s_export_op = &cfs_export_operations;
 

--- a/kernel/lcfs-reader.c
+++ b/kernel/lcfs-reader.c
@@ -117,8 +117,15 @@ struct lcfs_context_s *lcfs_create_ctx(char *descriptor_path, const u8 *required
 		kfree(ctx);
 		return ERR_CAST(header);
 	}
-	header->inode_len = lcfs_u32_from_file(header->inode_len);
+	header->magic = lcfs_u32_from_file(header->magic);
 	header->data_offset = lcfs_u64_from_file(header->data_offset);
+
+        if (header->magic != LCFS_MAGIC ||
+            header->data_offset > ctx->descriptor_len) {
+		fput(descriptor);
+		kfree(ctx);
+		return ERR_PTR(-EINVAL);
+	}
 
 	return ctx;
 }

--- a/kernel/lcfs.h
+++ b/kernel/lcfs.h
@@ -33,6 +33,8 @@ typedef uint64_t u64;
 
 #define LCFS_DIGEST_SIZE 32
 
+#define LCFS_MAGIC 0xc078629aU
+
 typedef u64 lcfs_off_t;
 
 typedef lcfs_off_t lcfs_c_str_t;
@@ -145,7 +147,7 @@ struct lcfs_header_s {
 	u8 unused1;
 	uint16_t unused2;
 
-	u32 inode_len;
+	u32 magic;
 	lcfs_off_t data_offset;
 
 	u64 unused3[3];

--- a/tools/lcfs/lcfs-writer.c
+++ b/tools/lcfs/lcfs-writer.c
@@ -673,7 +673,7 @@ int lcfs_write_to(struct lcfs_node_s *root, FILE *out)
 {
 	struct lcfs_header_s header = {
 		.version = LCFS_VERSION,
-		.inode_len = lcfs_u32_to_file(sizeof(struct lcfs_inode_s)),
+		.magic = lcfs_u32_to_file(LCFS_MAGIC),
 	};
 	int ret = 0;
 	struct lcfs_ctx_s *ctx;

--- a/tools/lcfs/lcfs.h
+++ b/tools/lcfs/lcfs.h
@@ -27,6 +27,8 @@
 
 #define LCFS_DIGEST_SIZE 32
 
+#define LCFS_MAGIC 0xc078629aU
+
 typedef uint64_t lcfs_off_t;
 
 typedef lcfs_off_t lcfs_c_str_t;
@@ -113,7 +115,7 @@ struct lcfs_header_s {
 	uint8_t unused1;
 	uint16_t unused2;
 
-	uint32_t inode_len;
+	uint32_t magic;
 	lcfs_off_t data_offset;
 
 	uint64_t unused3[3];


### PR DESCRIPTION
This ia a "more random" value, plus we can use it for sniffing and
quick validation. This replaces the inode_size in the header because
we don't really use that anywmore.

Signed-off-by: Alexander Larsson <alexl@redhat.com>