### PR TITLE
Store payload before inode data

### DIFF
--- a/kernel/lcfs.h
+++ b/kernel/lcfs.h
@@ -149,8 +149,9 @@ struct lcfs_header_s {
 
 	u32 magic;
 	lcfs_off_t data_offset;
+	lcfs_off_t root_inode;
 
-	u64 unused3[3];
+	u64 unused3[2];
 } __attribute__((packed));
 
 enum lcfs_inode_flags {

--- a/tools/dump.c
+++ b/tools/dump.c
@@ -77,13 +77,14 @@ static void decode_inode(const uint8_t *inode_data, lcfs_off_t inod_num, struct 
 	memset(ino, 0, sizeof(struct lcfs_inode_s));
 
 	ino->flags = decode_uint32(&data);
-	payload_data = inode_data + inod_num + lcfs_inode_encoded_size(ino->flags);
 
 	if (LCFS_INODE_FLAG_CHECK(ino->flags, PAYLOAD)) {
 		ino->payload_length = decode_uint32(&data);
 	} else {
 		ino->payload_length = 0;
 	}
+
+	payload_data = inode_data + inod_num  - ino->payload_length;
 
 	if (LCFS_INODE_FLAG_CHECK(ino->flags, MODE)) {
 		ino->st_mode = decode_uint32(&data);
@@ -379,7 +380,7 @@ int main(int argc, char *argv[])
 
 	inode_data = data + sizeof(struct lcfs_header_s);
 	vdata = data + lcfs_u64_from_file(header->data_offset);
-	root_index = 0;
+	root_index = lcfs_u64_from_file(header->root_inode);
 	if (mode == DUMP) {
 		dump_inode(inode_data, vdata, "", 0, root_index, 0, false, false, true);
 	} else if (mode == DUMP_EXTENDED) {

--- a/tools/lcfs/lcfs.h
+++ b/tools/lcfs/lcfs.h
@@ -117,8 +117,9 @@ struct lcfs_header_s {
 
 	uint32_t magic;
 	lcfs_off_t data_offset;
+	lcfs_off_t root_inode;
 
-	uint64_t unused3[3];
+	uint64_t unused3[2];
 } __attribute__((packed));
 
 


### PR DESCRIPTION
This means we can just subtract the payload length from the inode
offset to find it, rather than having to compute the inode
length. This in turn allows us to later grow the inode data
(using new flags) without affecting older kernel implementations,
as they will just ignore the data for flags it doesn't understand.

To find the root inode we now need to store its offset in the
descriptor header.

Signed-off-by: Alexander Larsson <alexl@redhat.com>