### PR TITLE
src: drop STANDALONE_COMPOSEFS define

### DIFF
--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -2,6 +2,4 @@
 
 obj-m += composefs.o
 
-KBUILD_CFLAGS += -DSTANDALONE_COMPOSEFS=1
-
 composefs-objs += lcfs-reader.o cfs.o

--- a/kernel/cfs.c
+++ b/kernel/cfs.c
@@ -30,12 +30,8 @@
 
 #include "lcfs-reader.h"
 
-#ifdef STANDALONE_COMPOSEFS
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("Giuseppe Scrivano <gscrivan@redhat.com>");
-#else
-#include "cfs.h"
-#endif
 
 #include "lcfs-verity.h"
 
@@ -874,7 +870,6 @@ static void cfs_inode_init_once(void *foo)
 	inode_init_once(&cino->vfs_inode);
 }
 
-#ifdef STANDALONE_COMPOSEFS
 static int __init init_cfs(void)
 {
 	cfs_inode_cachep = kmem_cache_create("cfs_inode",
@@ -900,12 +895,3 @@ static void __exit exit_cfs(void)
 
 module_init(init_cfs);
 module_exit(exit_cfs);
-
-#else
-
-struct vfsmount *cfs_mount(void *raw_data)
-{
-	return vfs_kern_mount(&cfs_type, 0, "", raw_data);
-}
-
-#endif

--- a/kernel/lcfs-verity.h
+++ b/kernel/lcfs-verity.h
@@ -13,7 +13,6 @@
 # include <linux/fsverity.h>
 #endif
 
-#ifdef STANDALONE_COMPOSEFS
 /* For whatever reason, struct fsverity_info is in a private header, even though
    fsverity_get_info() is in the public header. For now, just duplicate enough
    to implement lcfs_fsverity_info_get_digest() locally, but for upstreaming we
@@ -46,9 +45,6 @@ struct fsverity_info {
         u8 file_digest[FS_VERITY_MAX_DIGEST_SIZE];
         const struct inode *inode;
 };
-#else
-#include <fs/verity/fsverity_private.h>
-#endif
 
 static inline u8 *lcfs_fsverity_info_get_digest(struct fsverity_info *verity_info, size_t *digest_size) {
 	*digest_size = verity_info->tree_params.digest_size;


### PR DESCRIPTION
it was used as an experiment to embed composefs inside the overlayfs
driver itself.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>