### PR TITLE
Split out the libcomposefs Makefile to make it usable as a git submodule

### DIFF
--- a/libcomposefs/Makefile-lib.am
+++ b/libcomposefs/Makefile-lib.am
@@ -1,0 +1,12 @@
+COMPOSEFS_HASH_CFLAGS = -DUSE_OBSTACK=0 -DTESTING=0 -DUSE_DIFF_HASH=0
+
+libcomposefs_la_SOURCES = \
+                        $(COMPOSEFSDIR)/bitrotate.h \
+                        $(COMPOSEFSDIR)/hash.c \
+                        $(COMPOSEFSDIR)hash.h \
+                        $(COMPOSEFSDIR)/lcfs.h \
+                        $(COMPOSEFSDIR)/lcfs-writer.c \
+                        $(COMPOSEFSDIR)/lcfs-writer.h \
+                        $(COMPOSEFSDIR)/xalloc-oversized.h
+libcomposefs_la_CFLAGS = $(WARN_CFLAGS) $(COMPOSEFS_HASH_CFLAGS)  $(FSVERITY_CFLAGS)
+libcomposefs_la_LIBADD = $(FSVERITY_LIBS)

--- a/libcomposefs/Makefile.am
+++ b/libcomposefs/Makefile.am
@@ -1,10 +1,8 @@
-HASH_CFLAGS = -DUSE_OBSTACK=0 -DTESTING=0 -DUSE_DIFF_HASH=0
-
 lib_LTLIBRARIES = libcomposefs.la
 
 libcomposefsincludedir = $(includedir)/libcomposefs
 libcomposefsinclude_HEADERS = lcfs-writer.h
 
-libcomposefs_la_SOURCES = bitrotate.h hash.c hash.h lcfs.h lcfs-writer.c lcfs-writer.h xalloc-oversized.h
-libcomposefs_la_CFLAGS = $(WARN_CFLAGS) $(HASH_CFLAGS)  $(FSVERITY_CFLAGS)
-libcomposefs_la_LIBADD = $(FSVERITY_LIBS)
+# We split the library out so it can be used easily as a git submodule
+COMPOSEFSDIR = .
+include Makefile-lib.am


### PR DESCRIPTION
This can be used for e.g. ostree

Signed-off-by: Alexander Larsson <alexl@redhat.com>