### PR TITLE
Fsverity rework

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,7 @@ AM_INIT_AUTOMAKE([1.11.2 -Wno-portability foreign tar-ustar no-dist-gzip dist-xz
 AC_PROG_CC
 
 PKG_CHECK_MODULES(FSVERITY, libfsverity)
+PKG_CHECK_MODULES(LIBCRYPTO, libcrypto)
 
 AC_DEFUN([CC_CHECK_FLAG_APPEND], [
   AC_CACHE_CHECK([if $CC supports flag $3 in envvar $2],

--- a/libcomposefs/Makefile-lib.am
+++ b/libcomposefs/Makefile-lib.am
@@ -5,8 +5,10 @@ libcomposefs_la_SOURCES = \
                         $(COMPOSEFSDIR)/hash.c \
                         $(COMPOSEFSDIR)hash.h \
                         $(COMPOSEFSDIR)/lcfs.h \
+                        $(COMPOSEFSDIR)/lcfs-fsverity.c \
+                        $(COMPOSEFSDIR)/lcfs-fsvertiy.h \
                         $(COMPOSEFSDIR)/lcfs-writer.c \
                         $(COMPOSEFSDIR)/lcfs-writer.h \
                         $(COMPOSEFSDIR)/xalloc-oversized.h
-libcomposefs_la_CFLAGS = $(WARN_CFLAGS) $(COMPOSEFS_HASH_CFLAGS) $(FSVERITY_CFLAGS)
-libcomposefs_la_LIBADD = $(FSVERITY_LIBS)
+libcomposefs_la_CFLAGS = $(WARN_CFLAGS) $(COMPOSEFS_HASH_CFLAGS) $(LIBCRYPTO_CFLAGS)
+libcomposefs_la_LIBADD = $(LIBCRYPTO_LIBS)

--- a/libcomposefs/lcfs-fsverity.c
+++ b/libcomposefs/lcfs-fsverity.c
@@ -1,0 +1,160 @@
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <endian.h>
+#include <assert.h>
+#include <string.h>
+#include <sys/param.h>
+
+/* For sha256 computation */
+#include <openssl/evp.h>
+
+#include "lcfs-fsverity.h"
+
+struct fsverity_descriptor {
+	uint8_t version;
+	uint8_t hash_algorithm;
+	uint8_t log_blocksize;
+	uint8_t salt_size;
+	uint32_t reserved1;
+	uint64_t data_size_be;
+	uint8_t root_hash[64];
+	uint8_t salt[32];
+	uint8_t reserved2[144];
+};
+
+#define FSVERITY_BLOCK_SIZE 4096
+#define FSVERITY_MAX_LEVELS 8 /* enough for 64bit file size */
+
+struct FsVerityContext {
+	uint8_t buffer[FSVERITY_MAX_LEVELS][FSVERITY_BLOCK_SIZE];
+	uint32_t buffer_pos[FSVERITY_MAX_LEVELS];
+	uint32_t max_level;
+	uint64_t file_size;
+	EVP_MD_CTX *md_ctx;
+};
+
+FsVerityContext *lcfs_fsverity_context_new(void)
+{
+	FsVerityContext *ctx;
+
+	ctx = calloc(1, sizeof(FsVerityContext));
+	if (ctx == NULL)
+		return NULL;
+
+	ctx->md_ctx = EVP_MD_CTX_create();
+	if (ctx->md_ctx == NULL) {
+		free(ctx);
+		return NULL;
+	}
+
+	return ctx;
+}
+
+void lcfs_fsverity_context_free(FsVerityContext *ctx)
+{
+	EVP_MD_CTX_destroy(ctx->md_ctx);
+	free(ctx);
+}
+
+static void do_sha256(FsVerityContext *ctx, const uint8_t *data,
+		      size_t data_len, uint8_t *digest)
+{
+	const EVP_MD *md = EVP_sha256();
+	int ret;
+
+	assert(md != NULL);
+
+	ret = EVP_DigestInit_ex(ctx->md_ctx, md, NULL);
+	assert(ret == 1);
+
+	ret = EVP_DigestUpdate(ctx->md_ctx, data, data_len);
+	assert(ret == 1);
+
+	ret = EVP_DigestFinal_ex(ctx->md_ctx, digest, NULL);
+	assert(ret == 1);
+}
+
+static void lcfs_fsverity_context_update_level(FsVerityContext *ctx,
+					       uint8_t *data, size_t data_len,
+					       uint32_t level)
+{
+	assert(level < FSVERITY_MAX_LEVELS);
+
+	if (level > ctx->max_level)
+		ctx->max_level = level;
+
+	while (data_len > 0) {
+		/* First check if block is already full, we want to do this lazyly
+		   so we only flush to the next level if there is more data after
+		   the block is full */
+		if (ctx->buffer_pos[level] == FSVERITY_BLOCK_SIZE) {
+			uint8_t digest[32];
+			do_sha256(ctx, ctx->buffer[level], FSVERITY_BLOCK_SIZE,
+				  digest);
+			lcfs_fsverity_context_update_level(ctx, digest, 32,
+							   level + 1);
+			ctx->buffer_pos[level] = 0;
+		}
+
+		size_t to_copy = MIN(
+			FSVERITY_BLOCK_SIZE - ctx->buffer_pos[level], data_len);
+
+		memcpy(ctx->buffer[level] + ctx->buffer_pos[level], data,
+		       to_copy);
+		ctx->buffer_pos[level] += to_copy;
+
+		data += to_copy;
+		data_len -= to_copy;
+	}
+}
+
+void lcfs_fsverity_context_update(FsVerityContext *ctx, void *data,
+				  size_t data_len)
+{
+	lcfs_fsverity_context_update_level(ctx, data, data_len, 0);
+	ctx->file_size += data_len;
+}
+
+static void lcfs_fsverity_context_flush_level(FsVerityContext *ctx,
+					      uint32_t level)
+{
+	uint8_t digest[32];
+
+	if (ctx->buffer_pos[level] < FSVERITY_BLOCK_SIZE) {
+		memset(ctx->buffer[level] + ctx->buffer_pos[level], 0,
+		       FSVERITY_BLOCK_SIZE - ctx->buffer_pos[level]);
+		ctx->buffer_pos[level] = FSVERITY_BLOCK_SIZE;
+	}
+
+	if (level == ctx->max_level)
+		return;
+
+	do_sha256(ctx, ctx->buffer[level], FSVERITY_BLOCK_SIZE, digest);
+	lcfs_fsverity_context_update_level(ctx, digest, 32, level + 1);
+
+	lcfs_fsverity_context_flush_level(ctx, level + 1);
+}
+
+void lcfs_fsverity_context_get_digest(FsVerityContext *ctx, uint8_t digest[32])
+{
+	struct fsverity_descriptor descriptor;
+
+	lcfs_fsverity_context_flush_level(ctx, 0);
+
+	memset(&descriptor, 0, sizeof(descriptor));
+	descriptor.version = 1;
+	descriptor.hash_algorithm = 1;
+	descriptor.log_blocksize = 12;
+	descriptor.salt_size = 0;
+	descriptor.data_size_be = htole64(ctx->file_size);
+
+	do_sha256(ctx, ctx->buffer[ctx->max_level], FSVERITY_BLOCK_SIZE,
+		  descriptor.root_hash);
+
+	do_sha256(ctx, (uint8_t *)&descriptor, sizeof(descriptor), digest);
+}

--- a/libcomposefs/lcfs-fsverity.h
+++ b/libcomposefs/lcfs-fsverity.h
@@ -1,0 +1,9 @@
+#include <stdint.h>
+
+typedef struct FsVerityContext FsVerityContext;
+
+FsVerityContext *lcfs_fsverity_context_new(void);
+void lcfs_fsverity_context_free(FsVerityContext *ctx);
+void lcfs_fsverity_context_update(FsVerityContext *ctx, void *data,
+				  size_t data_len);
+void lcfs_fsverity_context_get_digest(FsVerityContext *ctx, uint8_t digest[32]);

--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -945,7 +945,13 @@ int lcfs_node_set_fsverity_from_content(struct lcfs_node_s *node, void *file,
 static ssize_t fsverity_read_cb(void *_fd, void *buf, size_t count)
 {
 	int fd = *(int *)_fd;
-	return read(fd, buf, count);
+	ssize_t res;
+
+	do
+		res = read(fd, buf, count);
+	while (res < 0 && errno == EINTR);
+
+	return res;
 }
 
 int lcfs_node_set_fsverity_from_fd(struct lcfs_node_s *node, int fd)

--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -902,7 +902,7 @@ int lcfs_node_set_fsverity_from_content(struct lcfs_node_s *node, void *file,
 	return 0;
 }
 
-static int fsverity_read_cb(void *_fd, void *buf, size_t count)
+static ssize_t fsverity_read_cb(void *_fd, void *buf, size_t count)
 {
 	int fd = *(int *)_fd;
 	return read(fd, buf, count);

--- a/libcomposefs/lcfs-writer.h
+++ b/libcomposefs/lcfs-writer.h
@@ -97,6 +97,7 @@ struct lcfs_node_s *lcfs_build(struct lcfs_node_s *parent, int dirfd,
 			       const char *fname, const char *name,
 			       int buildflags);
 
-int lcfs_write_to(struct lcfs_node_s *root, void *file, lcfs_write_cb write_cb);
+int lcfs_write_to(struct lcfs_node_s *root, void *file, lcfs_write_cb write_cb,
+		  uint8_t *digest_out);
 
 #endif

--- a/libcomposefs/lcfs-writer.h
+++ b/libcomposefs/lcfs-writer.h
@@ -89,10 +89,9 @@ void lcfs_node_set_fsverity_digest(struct lcfs_node_s *node,
 				   uint8_t digest[32]);
 
 int lcfs_node_set_fsverity_from_content(struct lcfs_node_s *node, void *file,
-					uint64_t size, lcfs_read_cb read_cb);
+					lcfs_read_cb read_cb);
 
-int lcfs_node_set_fsverity_from_fd(struct lcfs_node_s *node, int fd,
-				   uint64_t size);
+int lcfs_node_set_fsverity_from_fd(struct lcfs_node_s *node, int fd);
 
 struct lcfs_node_s *lcfs_build(struct lcfs_node_s *parent, int dirfd,
 			       const char *fname, const char *name,

--- a/libcomposefs/lcfs-writer.h
+++ b/libcomposefs/lcfs-writer.h
@@ -33,8 +33,8 @@ enum {
 	LCFS_BUILD_COMPUTE_DIGEST = (1 << 3),
 };
 
-typedef int (*lcfs_read_cb)(void *file, void *buf, size_t count);
-typedef int (*lcfs_write_cb)(void *file, void *buf, size_t count);
+typedef ssize_t (*lcfs_read_cb)(void *file, void *buf, size_t count);
+typedef ssize_t (*lcfs_write_cb)(void *file, void *buf, size_t count);
 
 struct lcfs_node_s *lcfs_node_new(void);
 struct lcfs_node_s *lcfs_node_ref(struct lcfs_node_s *node);

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -5,13 +5,13 @@ if USE_YAJL
 noinst_PROGRAMS += writer-json
 endif
 
-AM_CFLAGS = $(WARN_CFLAGS)
+AM_CFLAGS = $(WARN_CFLAGS) $(FSVERITY_CFLAGS)
 
 dump_SOURCES = dump.c
-dump_LDADD = ../libcomposefs/libcomposefs.la $(FSVERITY_LIBS)
+dump_LDADD = ../libcomposefs/libcomposefs.la $(LIBCRYPTO_LIBS)
 
 mkcomposefs_SOURCES = mkcomposefs.c
-mkcomposefs_LDADD =  ../libcomposefs/libcomposefs.la $(FSVERITY_LIBS)
+mkcomposefs_LDADD =  ../libcomposefs/libcomposefs.la $(LIBCRYPTO_LIBS) $(FSVERITY_LIBS)
 
 writer_json_SOURCES = writer-json.c read-file.c read-file.h
-writer_json_LDADD = ../libcomposefs/libcomposefs.la $(LIBS_YAJL) $(FSVERITY_LIBS)
+writer_json_LDADD = ../libcomposefs/libcomposefs.la $(LIBS_YAJL) $(LIBCRYPTO_LIBS)

--- a/tools/mkcomposefs.c
+++ b/tools/mkcomposefs.c
@@ -505,7 +505,7 @@ int main(int argc, char **argv)
 	fill_payload(root, pathbuf, strlen(pathbuf), path_start_offset,
 		     by_digest, digest_store_path);
 
-	if (lcfs_write_to(root, out_file, write_cb) < 0)
+	if (lcfs_write_to(root, out_file, write_cb, NULL) < 0)
 		error(EXIT_FAILURE, errno, "cannot write to stdout");
 
 	lcfs_node_unref(root);

--- a/tools/mkcomposefs.c
+++ b/tools/mkcomposefs.c
@@ -341,7 +341,7 @@ static void usage(const char *argv0)
 #define OPT_BY_DIGEST 107
 #define OPT_DIGEST_STORE 108
 
-static int write_cb(void *_file, void *buf, size_t count)
+static ssize_t write_cb(void *_file, void *buf, size_t count)
 {
 	FILE *file = _file;
 

--- a/tools/writer-json.c
+++ b/tools/writer-json.c
@@ -422,7 +422,7 @@ static void usage(const char *argv0)
 	fprintf(stderr, "usage: %s [--out=filedname] jsonfile...\n", argv0);
 }
 
-static int write_cb(void *_file, void *buf, size_t count)
+static ssize_t write_cb(void *_file, void *buf, size_t count)
 {
 	FILE *file = _file;
 

--- a/tools/writer-json.c
+++ b/tools/writer-json.c
@@ -501,7 +501,7 @@ int main(int argc, char **argv)
 	if (getcwd(cwd, sizeof(cwd)) == NULL)
 		error(EXIT_FAILURE, errno, "get current working directory");
 
-	if (lcfs_write_to(root, out_file, write_cb) < 0)
+	if (lcfs_write_to(root, out_file, write_cb, NULL) < 0)
 		error(EXIT_FAILURE, errno, "cannot write to stdout");
 
 	lcfs_node_unref(root);


### PR DESCRIPTION
This uses a custom fsverity hash implementation to allow us to compute the digest while writing the descriptor. And some cleanups.