### PR TITLE
Limit in-memory use for inodes

### DIFF
--- a/kernel/Documentation/filesystems/composefs.rst
+++ b/kernel/Documentation/filesystems/composefs.rst
@@ -141,7 +141,8 @@ payload length attribute gives the size of the variable chunk.
 
 The inode variable chunk contains different things depending on the
 file type.  For regular files it is the backing filename. For symlinks
-it is the symlink target. For directories it is a list of dentries.
+it is the symlink target. For directories it is a list of dentries,
+stored in chunks of maximum 4k.
 
 The variable data section is stored after the inode section, and you
 can find it from the offset in the header. It contains Xattrs data

--- a/kernel/cfs-reader.c
+++ b/kernel/cfs-reader.c
@@ -492,6 +492,10 @@ struct cfs_xattr_header_s *cfs_get_xattrs(struct cfs_context_s *ctx,
 	if (ino->xattrs.len < sizeof(struct cfs_xattr_header_s))
 		return ERR_PTR(-EFSCORRUPTED);
 
+	/* Don't allocate arbitriary size xattrs */
+	if (ino->xattrs.len > CFS_MAX_XATTRS_SIZE)
+		return ERR_PTR(-EFSCORRUPTED);
+
 	xattrs = cfs_alloc_vdata(ctx, ino->xattrs);
 	if (IS_ERR(xattrs))
 		return ERR_CAST(xattrs);

--- a/kernel/cfs-reader.c
+++ b/kernel/cfs-reader.c
@@ -413,7 +413,7 @@ struct cfs_dir_s *cfs_get_dir(struct cfs_context_s *ctx,
 	/* Verify and convert all dentries upfront */
 	for (i = 0; i < n_dentries; i++) {
 		struct cfs_dentry_s *d = &dir->dentries[i];
-		u16 name_len = d->name_len = cfs_u16_from_file(d->name_len);
+		u32 name_len = d->name_len;
 		d->inode_index = cfs_u64_from_file(d->inode_index);
 
 		/* name needs to fit in data */

--- a/kernel/cfs-reader.h
+++ b/kernel/cfs-reader.h
@@ -7,6 +7,13 @@
 
 struct cfs_context_s;
 
+#define CFS_N_PRELOAD_DIR_CHUNKS 4
+
+struct cfs_dir_data_s {
+	u32 n_chunks;
+	struct cfs_dir_chunk_s preloaded_chunks[CFS_N_PRELOAD_DIR_CHUNKS];
+};
+
 struct cfs_context_s *cfs_create_ctx(const char *descriptor_path,
 				     const u8 *required_digest);
 
@@ -22,8 +29,8 @@ const uint8_t *cfs_get_digest(struct cfs_context_s *ctx,
 			      struct cfs_inode_s *ino, const char *payload,
 			      u8 digest_buf[SHA256_DIGEST_SIZE]);
 
-struct cfs_dir_s *cfs_get_dir(struct cfs_context_s *ctx,
-			      struct cfs_inode_s *ino, u64 index);
+int cfs_get_dir_data(struct cfs_context_s *ctx, struct cfs_inode_s *ino,
+		     u64 index, struct cfs_dir_data_s *data);
 
 struct cfs_xattr_header_s *cfs_get_xattrs(struct cfs_context_s *ctx,
 					  struct cfs_inode_s *ino);
@@ -35,12 +42,13 @@ int cfs_get_xattr(struct cfs_xattr_header_s *xattrs, const char *name,
 typedef bool (*cfs_dir_iter_cb)(void *private, const char *name, int namelen,
 				u64 ino, unsigned int dtype);
 
-int cfs_dir_iterate(struct cfs_dir_s *dir, loff_t first, cfs_dir_iter_cb cb,
-		    void *private);
-u32 cfs_dir_get_link_count(struct cfs_dir_s *dir);
+int cfs_dir_iterate(struct cfs_context_s *ctx, u32 payload_length, u64 index,
+		    struct cfs_dir_data_s *dir, loff_t first,
+		    cfs_dir_iter_cb cb, void *private);
 
-int cfs_dir_lookup(struct cfs_dir_s *dir, const char *name, size_t name_len,
-		   u64 *index);
+int cfs_dir_lookup(struct cfs_context_s *ctx, u32 payload_length, u64 index,
+		   struct cfs_dir_data_s *dir, const char *name,
+		   size_t name_len, u64 *index_out);
 
 char *cfs_dup_payload_path(struct cfs_context_s *ctx, struct cfs_inode_s *ino,
 			   u64 index);

--- a/kernel/cfs.c
+++ b/kernel/cfs.c
@@ -288,6 +288,8 @@ struct dentry *cfs_lookup(struct inode *dir, struct dentry *dentry,
 
 	ret = cfs_dir_lookup(cino->dir, dentry->d_name.name, dentry->d_name.len,
 			     &index);
+	if (ret < 0)
+		return ERR_PTR(ret);
 	if (ret == 0)
 		goto return_negative;
 

--- a/kernel/cfs.c
+++ b/kernel/cfs.c
@@ -940,6 +940,7 @@ static int cfs_init_fs_context(struct fs_context *fc)
 }
 
 static struct file_system_type cfs_type = {
+	.owner = THIS_MODULE,
 	.name = "composefs",
 	.init_fs_context = cfs_init_fs_context,
 	.parameters = cfs_parameters,

--- a/kernel/cfs.c
+++ b/kernel/cfs.c
@@ -296,8 +296,10 @@ struct dentry *cfs_lookup(struct inode *dir, struct dentry *dentry,
 		return ERR_CAST(ino_s);
 
 	inode = cfs_make_inode(fsi->cfs_ctx, dir->i_sb, index, ino_s, dir);
-	if (inode)
-		return d_splice_alias(inode, dentry);
+	if (IS_ERR(inode))
+		return ERR_CAST(inode);
+
+	return d_splice_alias(inode, dentry);
 
 return_negative:
 	d_add(dentry, NULL);

--- a/kernel/cfs.h
+++ b/kernel/cfs.h
@@ -27,6 +27,8 @@
 
 #define CFS_MAGIC 0xc078629aU
 
+#define CFS_MAX_DIR_CHUNK_SIZE 4096
+
 static inline u16 cfs_u16_to_file(u16 val)
 {
 	return cpu_to_le16(val);
@@ -151,6 +153,7 @@ enum cfs_inode_flags {
 
 #define CFS_INODE_DEFAULT_MODE 0100644
 #define CFS_INODE_DEFAULT_NLINK 1
+#define CFS_INODE_DEFAULT_NLINK_DIR 2
 #define CFS_INODE_DEFAULT_UIDGID 0
 #define CFS_INODE_DEFAULT_RDEV 0
 #define CFS_INODE_DEFAULT_TIMES 0
@@ -210,13 +213,19 @@ struct cfs_dentry_s {
 	u8 d_type;
 } __attribute__((packed));
 
-struct cfs_dir_s {
-	u32 n_dentries;
-	struct cfs_dentry_s dentries[];
+struct cfs_dir_chunk_s {
+	u16 n_dentries;
+	u16 chunk_size;
 } __attribute__((packed));
 
-#define cfs_dir_size(_n_dentries)                                              \
-	(sizeof(struct cfs_dir_s) + (_n_dentries) * sizeof(struct cfs_dentry_s))
+struct cfs_dir_s {
+	u32 n_chunks;
+	struct cfs_dir_chunk_s chunks[];
+} __attribute__((packed));
+
+#define cfs_dir_size(_n_chunks)                                                \
+	(sizeof(struct cfs_dir_s) +                                            \
+	 (_n_chunks) * sizeof(struct cfs_dir_chunk_s))
 
 /* xattr representation.  */
 struct cfs_xattr_element_s {

--- a/kernel/cfs.h
+++ b/kernel/cfs.h
@@ -28,6 +28,7 @@
 #define CFS_MAGIC 0xc078629aU
 
 #define CFS_MAX_DIR_CHUNK_SIZE 4096
+#define CFS_MAX_XATTRS_SIZE 4096
 
 static inline u16 cfs_u16_to_file(u16 val)
 {

--- a/kernel/cfs.h
+++ b/kernel/cfs.h
@@ -206,9 +206,8 @@ static inline u32 cfs_inode_encoded_size(u32 flags)
 struct cfs_dentry_s {
 	/* Index of struct cfs_inode_s */
 	u64 inode_index;
-	u16 name_len;
+	u8 name_len;
 	u8 d_type;
-	u8 pad;
 } __attribute__((packed));
 
 struct cfs_dir_s {

--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -512,6 +512,13 @@ static int compute_xattrs(struct lcfs_ctx_s *ctx)
 		}
 		header_len = lcfs_xattr_header_size(node->n_xattrs);
 		buffer_len = header_len + data_length;
+
+		/* Limit to max xattrs size */
+		if (buffer_len > LCFS_MAX_XATTRS_SIZE) {
+			errno = EINVAL;
+			return -1;
+		}
+
 		buffer = calloc(1, buffer_len);
 		if (buffer == NULL) {
 			errno = ENOMEM;

--- a/libcomposefs/lcfs.h
+++ b/libcomposefs/lcfs.h
@@ -27,6 +27,8 @@
 
 #define LCFS_DIGEST_SIZE 32
 
+#define LCFS_MAX_NAME_LENGTH 255 /* max len of file name excluding NULL */
+
 #define LCFS_MAGIC 0xc078629aU
 
 static inline uint16_t lcfs_u16_to_file(uint16_t val)
@@ -209,9 +211,8 @@ static inline uint32_t lcfs_inode_encoded_size(uint32_t flags)
 struct lcfs_dentry_s {
 	/* Index of struct lcfs_inode_s */
 	uint64_t inode_index;
-	uint16_t name_len;
+	uint8_t name_len;
 	uint8_t d_type;
-	uint8_t pad;
 } __attribute__((packed));
 
 struct lcfs_dir_s {

--- a/libcomposefs/lcfs.h
+++ b/libcomposefs/lcfs.h
@@ -27,6 +27,8 @@
 
 #define LCFS_DIGEST_SIZE 32
 
+#define LCFS_MAX_DIR_CHUNK_SIZE 4096
+
 #define LCFS_MAX_NAME_LENGTH 255 /* max len of file name excluding NULL */
 
 #define LCFS_MAGIC 0xc078629aU
@@ -155,6 +157,7 @@ enum lcfs_inode_flags {
 
 #define LCFS_INODE_DEFAULT_MODE 0100644
 #define LCFS_INODE_DEFAULT_NLINK 1
+#define LCFS_INODE_DEFAULT_NLINK_DIR 2
 #define LCFS_INODE_DEFAULT_UIDGID 0
 #define LCFS_INODE_DEFAULT_RDEV 0
 #define LCFS_INODE_DEFAULT_TIMES 0
@@ -215,15 +218,19 @@ struct lcfs_dentry_s {
 	uint8_t d_type;
 } __attribute__((packed));
 
-struct lcfs_dir_s {
-	/* Index of struct lcfs_inode_s */
-	uint32_t n_dentries;
-	struct lcfs_dentry_s dentries[];
+struct lcfs_dir_chunk_s {
+	uint16_t n_dentries;
+	uint16_t chunk_size;
 } __attribute__((packed));
 
-#define lcfs_dir_size(_n_dentries)                                             \
+struct lcfs_dir_s {
+	uint32_t n_chunks;
+	struct lcfs_dir_chunk_s chunks[];
+} __attribute__((packed));
+
+#define lcfs_dir_size(_n_chunks)                                               \
 	(sizeof(struct lcfs_dir_s) +                                           \
-	 (_n_dentries) * sizeof(struct lcfs_dentry_s))
+	 (_n_chunks) * sizeof(struct lcfs_dir_chunk_s))
 
 /* xattr representation.  */
 struct lcfs_xattr_element_s {

--- a/libcomposefs/lcfs.h
+++ b/libcomposefs/lcfs.h
@@ -28,6 +28,7 @@
 #define LCFS_DIGEST_SIZE 32
 
 #define LCFS_MAX_DIR_CHUNK_SIZE 4096
+#define LCFS_MAX_XATTRS_SIZE 4096
 
 #define LCFS_MAX_NAME_LENGTH 255 /* max len of file name excluding NULL */
 

--- a/tools/dump.c
+++ b/tools/dump.c
@@ -272,8 +272,7 @@ static int dump_inode(const uint8_t *inode_data, const uint8_t *vdata,
 
 		namedata = (char *)dir + lcfs_dir_size(n_dentries);
 		for (i = 0; i < n_dentries; i++) {
-			child_name_len =
-				lcfs_u16_from_file(dir->dentries[i].name_len);
+			child_name_len = dir->dentries[i].name_len;
 			dump_inode(inode_data, vdata, namedata, child_name_len,
 				   lcfs_u64_from_file(
 					   dir->dentries[i].inode_index),
@@ -308,8 +307,7 @@ static uint64_t find_child(const uint8_t *inode_data, uint64_t current,
 	name_len = strlen(name);
 	namedata = (char *)dir + lcfs_dir_size(n_dentries);
 	for (i = 0; i < n_dentries; i++) {
-		size_t child_name_len =
-			lcfs_u16_from_file(dir->dentries[i].name_len);
+		size_t child_name_len = dir->dentries[i].name_len;
 		if (name_len == child_name_len &&
 		    memcmp(name, namedata, name_len) == 0) {
 			return lcfs_u64_from_file(dir->dentries[i].inode_index);


### PR DESCRIPTION
This limits the xattr data size to 4k, and splits the dentry data into chunks of (max) 4k which we read in chunks as needed. This drops the in-memory requirement for inodes a lot.

@rhvgoyal does this take care of your issues wrt memory use?

Note: For memory use I will also look at re-using xattr chunks in memory between inodes as they are already shared on disk. Should be rather easy.