### PR TITLE
Use page cache for xattrs

### DIFF
--- a/kernel/cfs-internals.h
+++ b/kernel/cfs-internals.h
@@ -9,15 +9,6 @@
 #define CFS_MAX_STACK 500
 #define CFS_N_PRELOAD_DIR_CHUNKS 4
 
-struct cfs_buf {
-	struct page *page;
-	void *base;
-};
-#define CFS_VDATA_BUF_INIT                                                     \
-	{                                                                      \
-		NULL, NULL                                                     \
-	}
-
 struct cfs_inode_data_s {
 	u32 payload_length;
 	char *path_payload; /* Real pathname for files, target for symlinks */

--- a/kernel/cfs-internals.h
+++ b/kernel/cfs-internals.h
@@ -24,6 +24,8 @@ struct cfs_inode_data_s {
 	u32 n_dir_chunks;
 	struct cfs_dir_chunk_s preloaded_dir_chunks[CFS_N_PRELOAD_DIR_CHUNKS];
 
+	struct cfs_xattr_header_s *xattrs;
+
 	bool has_digest;
 	uint8_t digest[SHA256_DIGEST_SIZE]; /* fs-verity digest */
 };
@@ -53,11 +55,9 @@ struct cfs_inode_s *cfs_get_ino_index(struct cfs_context_s *ctx, u64 index,
 int cfs_init_inode_data(struct cfs_context_s *ctx, struct cfs_inode_s *ino,
 			u64 index, struct cfs_inode_data_s *data);
 
-struct cfs_xattr_header_s *cfs_get_xattrs(struct cfs_context_s *ctx,
-					  struct cfs_inode_s *ino);
-ssize_t cfs_list_xattrs(struct cfs_xattr_header_s *xattrs, char *names,
+ssize_t cfs_list_xattrs(struct cfs_inode_data_s *inode_data, char *names,
 			size_t size);
-int cfs_get_xattr(struct cfs_xattr_header_s *xattrs, const char *name,
+int cfs_get_xattr(struct cfs_inode_data_s *inode_data, const char *name,
 		  void *value, size_t size);
 
 typedef bool (*cfs_dir_iter_cb)(void *private, const char *name, int namelen,

--- a/kernel/cfs-internals.h
+++ b/kernel/cfs-internals.h
@@ -71,7 +71,4 @@ int cfs_dir_lookup(struct cfs_context_s *ctx, u64 index,
 		   struct cfs_inode_data_s *inode_data, const char *name,
 		   size_t name_len, u64 *index_out);
 
-char *cfs_dup_payload_path(struct cfs_context_s *ctx, struct cfs_inode_s *ino,
-			   u64 index);
-
 #endif

--- a/kernel/cfs-internals.h
+++ b/kernel/cfs-internals.h
@@ -20,6 +20,7 @@ struct cfs_buf {
 
 struct cfs_inode_data_s {
 	u32 payload_length;
+	char *path_payload; /* Real pathname for files, target for symlinks */
 	u32 n_dir_chunks;
 	struct cfs_dir_chunk_s preloaded_dir_chunks[CFS_N_PRELOAD_DIR_CHUNKS];
 };
@@ -37,6 +38,8 @@ int cfs_init_ctx(const char *descriptor_path, const u8 *required_digest,
 		 struct cfs_context_s *ctx);
 
 void cfs_destroy_ctx(struct cfs_context_s *ctx);
+
+void cfs_inode_data_put(struct cfs_inode_data_s *inode_data);
 
 struct cfs_inode_s *cfs_get_root_ino(struct cfs_context_s *ctx,
 				     struct cfs_inode_s *ino_buf, u64 *index);

--- a/kernel/cfs-internals.h
+++ b/kernel/cfs-internals.h
@@ -23,6 +23,9 @@ struct cfs_inode_data_s {
 	char *path_payload; /* Real pathname for files, target for symlinks */
 	u32 n_dir_chunks;
 	struct cfs_dir_chunk_s preloaded_dir_chunks[CFS_N_PRELOAD_DIR_CHUNKS];
+
+	bool has_digest;
+	uint8_t digest[SHA256_DIGEST_SIZE]; /* fs-verity digest */
 };
 
 struct cfs_context_s {
@@ -46,10 +49,6 @@ struct cfs_inode_s *cfs_get_root_ino(struct cfs_context_s *ctx,
 
 struct cfs_inode_s *cfs_get_ino_index(struct cfs_context_s *ctx, u64 index,
 				      struct cfs_inode_s *buffer);
-
-const uint8_t *cfs_get_digest(struct cfs_context_s *ctx,
-			      struct cfs_inode_s *ino, const char *payload,
-			      u8 digest_buf[SHA256_DIGEST_SIZE]);
 
 int cfs_init_inode_data(struct cfs_context_s *ctx, struct cfs_inode_s *ino,
 			u64 index, struct cfs_inode_data_s *data);

--- a/kernel/cfs-internals.h
+++ b/kernel/cfs-internals.h
@@ -24,7 +24,8 @@ struct cfs_inode_data_s {
 	u32 n_dir_chunks;
 	struct cfs_dir_chunk_s preloaded_dir_chunks[CFS_N_PRELOAD_DIR_CHUNKS];
 
-	struct cfs_xattr_header_s *xattrs;
+	u64 xattrs_offset;
+	u32 xattrs_len;
 
 	bool has_digest;
 	uint8_t digest[SHA256_DIGEST_SIZE]; /* fs-verity digest */
@@ -55,9 +56,11 @@ struct cfs_inode_s *cfs_get_ino_index(struct cfs_context_s *ctx, u64 index,
 int cfs_init_inode_data(struct cfs_context_s *ctx, struct cfs_inode_s *ino,
 			u64 index, struct cfs_inode_data_s *data);
 
-ssize_t cfs_list_xattrs(struct cfs_inode_data_s *inode_data, char *names,
+ssize_t cfs_list_xattrs(struct cfs_context_s *ctx,
+			struct cfs_inode_data_s *inode_data, char *names,
 			size_t size);
-int cfs_get_xattr(struct cfs_inode_data_s *inode_data, const char *name,
+int cfs_get_xattr(struct cfs_context_s *ctx,
+		  struct cfs_inode_data_s *inode_data, const char *name,
 		  void *value, size_t size);
 
 typedef bool (*cfs_dir_iter_cb)(void *private, const char *name, int namelen,

--- a/kernel/cfs-internals.h
+++ b/kernel/cfs-internals.h
@@ -42,7 +42,7 @@ struct cfs_context_s {
 int cfs_init_ctx(const char *descriptor_path, const u8 *required_digest,
 		 struct cfs_context_s *ctx);
 
-void cfs_destroy_ctx(struct cfs_context_s *ctx);
+void cfs_ctx_put(struct cfs_context_s *ctx);
 
 void cfs_inode_data_put(struct cfs_inode_data_s *inode_data);
 

--- a/kernel/cfs-reader.c
+++ b/kernel/cfs-reader.c
@@ -170,7 +170,7 @@ int cfs_init_ctx(const char *descriptor_path, const u8 *required_digest,
 	return 0;
 }
 
-void cfs_destroy_ctx(struct cfs_context_s *ctx)
+void cfs_ctx_put(struct cfs_context_s *ctx)
 {
 	if (ctx->descriptor) {
 		fput(ctx->descriptor);

--- a/kernel/cfs-reader.c
+++ b/kernel/cfs-reader.c
@@ -20,6 +20,9 @@
 #include <linux/unaligned/packed_struct.h>
 #include <linux/sched/mm.h>
 
+static char *cfs_dup_payload_path(struct cfs_context_s *ctx,
+				  struct cfs_inode_s *ino, u64 index);
+
 static struct cfs_xattr_header_s *cfs_get_xattrs(struct cfs_context_s *ctx,
 						 struct cfs_inode_s *ino);
 
@@ -974,8 +977,8 @@ exit:
 	return res;
 }
 
-char *cfs_dup_payload_path(struct cfs_context_s *ctx, struct cfs_inode_s *ino,
-			   u64 index)
+static char *cfs_dup_payload_path(struct cfs_context_s *ctx,
+				  struct cfs_inode_s *ino, u64 index)
 {
 	const char *v;
 	u8 *path;

--- a/kernel/cfs-reader.c
+++ b/kernel/cfs-reader.c
@@ -23,9 +23,6 @@
 static char *cfs_dup_payload_path(struct cfs_context_s *ctx,
 				  struct cfs_inode_s *ino, u64 index);
 
-static struct cfs_xattr_header_s *cfs_get_xattrs(struct cfs_context_s *ctx,
-						 struct cfs_inode_s *ino);
-
 static void cfs_buf_put(struct cfs_buf *buf)
 {
 	if (buf->page) {
@@ -237,38 +234,6 @@ static void *cfs_get_vdata_buf(struct cfs_context_s *ctx, u64 offset, u32 len,
 		return ERR_PTR(-EINVAL);
 
 	return cfs_get_buf(ctx, ctx->header.data_offset + offset, len, buf);
-}
-
-static void *cfs_read_vdata(struct cfs_context_s *ctx, u64 offset, u32 len,
-			    void *dest)
-{
-	if (!dest)
-		return NULL;
-
-	return cfs_read_data(ctx, ctx->header.data_offset + offset, len, dest);
-}
-
-static void *cfs_get_vdata(struct cfs_context_s *ctx,
-			   const struct cfs_vdata_s vdata, void *dest)
-{
-	return cfs_read_vdata(ctx, vdata.off, vdata.len, dest);
-}
-
-static void *cfs_alloc_vdata(struct cfs_context_s *ctx,
-			     const struct cfs_vdata_s vdata)
-{
-	u8 *buf;
-	void *res;
-
-	buf = kmalloc(vdata.len, GFP_KERNEL);
-	if (!buf)
-		return ERR_PTR(-ENOMEM);
-
-	res = cfs_get_vdata(ctx, vdata, buf);
-	if (IS_ERR(res))
-		kfree(buf);
-
-	return res;
 }
 
 static u32 cfs_read_u32(u8 **data)
@@ -509,7 +474,6 @@ int cfs_init_inode_data(struct cfs_context_s *ctx, struct cfs_inode_s *ino,
 	int ret = 0;
 	size_t i;
 	char *path_payload = NULL;
-	struct cfs_xattr_header_s *xattrs;
 
 	inode_data->payload_length = ino->payload_length;
 
@@ -546,12 +510,18 @@ int cfs_init_inode_data(struct cfs_context_s *ctx, struct cfs_inode_s *ino,
 
 	inode_data->has_digest = ret != 0;
 
-	xattrs = cfs_get_xattrs(ctx, ino);
-	if (IS_ERR(xattrs)) {
-		ret = PTR_ERR(xattrs);
-		goto fail;
+	inode_data->xattrs_offset = ino->xattrs.off;
+	inode_data->xattrs_len = ino->xattrs.len;
+
+	if (inode_data->xattrs_len != 0) {
+		/* Validate xattr size */
+		if (inode_data->xattrs_len <
+			    sizeof(struct cfs_xattr_header_s) ||
+		    inode_data->xattrs_len > CFS_MAX_XATTRS_SIZE) {
+			ret = -EFSCORRUPTED;
+			goto fail;
+		}
 	}
-	inode_data->xattrs = xattrs;
 
 	return 0;
 
@@ -567,157 +537,144 @@ void cfs_inode_data_put(struct cfs_inode_data_s *inode_data)
 		kfree(inode_data->path_payload);
 		inode_data->path_payload = NULL;
 	}
-	if (inode_data->xattrs) {
-		kfree(inode_data->xattrs);
-		inode_data->xattrs = NULL;
-	}
 }
 
-static struct cfs_xattr_header_s *cfs_get_xattrs(struct cfs_context_s *ctx,
-						 struct cfs_inode_s *ino)
-{
-	struct cfs_xattr_header_s *xattrs = NULL;
-	u8 *data, *data_end;
-	size_t n_xattrs, i;
-
-	if (ino->xattrs.len == 0) {
-		return NULL;
-	}
-
-	/* Gotta be large enought to fit the n_attr */
-	if (ino->xattrs.len < sizeof(struct cfs_xattr_header_s))
-		return ERR_PTR(-EFSCORRUPTED);
-
-	/* Don't allocate arbitriary size xattrs */
-	if (ino->xattrs.len > CFS_MAX_XATTRS_SIZE)
-		return ERR_PTR(-EFSCORRUPTED);
-
-	xattrs = cfs_alloc_vdata(ctx, ino->xattrs);
-	if (IS_ERR(xattrs))
-		return ERR_CAST(xattrs);
-
-	n_xattrs = xattrs->n_attr = cfs_u16_from_file(xattrs->n_attr);
-
-	/* Verify that array fits */
-	if (ino->xattrs.len < cfs_xattr_header_size(n_xattrs))
-		goto corrupted;
-
-	data = ((u8 *)xattrs) + cfs_xattr_header_size(n_xattrs);
-	data_end = ((u8 *)xattrs) + ino->xattrs.len;
-
-	/* Verify and convert all keys and value sizes upfront */
-	for (i = 0; i < n_xattrs; i++) {
-		struct cfs_xattr_element_s *e = &xattrs->attr[i];
-		uint16_t key_len = e->key_length =
-			cfs_u16_from_file(e->key_length);
-		uint16_t value_len = e->value_length =
-			cfs_u16_from_file(e->value_length);
-		if (key_len > XATTR_NAME_MAX)
-			goto corrupted;
-
-		/* key needs to fit in data */
-		if (data_end - data < key_len)
-			goto corrupted;
-		data += key_len;
-
-		/* value needs to fit in data */
-		if (data_end - data < value_len)
-			goto corrupted;
-		data += value_len;
-	}
-
-	/* No unexpected data at the end */
-	if (data != data_end)
-		goto corrupted;
-
-	return xattrs;
-
-corrupted:
-	kfree(xattrs);
-	return ERR_PTR(-EFSCORRUPTED);
-}
-
-ssize_t cfs_list_xattrs(struct cfs_inode_data_s *inode_data, char *names,
+ssize_t cfs_list_xattrs(struct cfs_context_s *ctx,
+			struct cfs_inode_data_s *inode_data, char *names,
 			size_t size)
 {
-	u8 *data;
+	u8 *data, *data_end;
 	size_t n_xattrs = 0, i;
 	ssize_t copied = 0;
-	struct cfs_xattr_header_s *xattrs = inode_data->xattrs;
+	const struct cfs_xattr_header_s *xattrs;
+	struct cfs_buf vdata_buf = CFS_VDATA_BUF_INIT;
 
-	if (xattrs == NULL)
+	if (inode_data->xattrs_len == 0)
 		return 0;
 
-	/* The contents was verified in cfs_get_xattrs, so trust it here */
-	n_xattrs = xattrs->n_attr;
+	/* xattrs_len basic size req was verified in cfs_init_inode_data */
+
+	xattrs = cfs_get_vdata_buf(ctx, inode_data->xattrs_offset,
+				   inode_data->xattrs_len, &vdata_buf);
+	if (IS_ERR(xattrs))
+		return PTR_ERR(xattrs);
+
+	n_xattrs = cfs_u16_from_file(xattrs->n_attr);
+
+	/* Verify that array fits */
+	if (inode_data->xattrs_len < cfs_xattr_header_size(n_xattrs)) {
+		copied = -EFSCORRUPTED;
+		goto exit;
+	}
 
 	data = ((u8 *)xattrs) + cfs_xattr_header_size(n_xattrs);
+	data_end = ((u8 *)xattrs) + inode_data->xattrs_len;
 
 	for (i = 0; i < n_xattrs; i++) {
-		uint16_t key_len = xattrs->attr[i].key_length;
-		uint16_t value_len = xattrs->attr[i].value_length;
+		const struct cfs_xattr_element_s *e = &xattrs->attr[i];
+		uint16_t this_key_len = cfs_u16_from_file(e->key_length);
+		uint16_t this_value_len = cfs_u16_from_file(e->value_length);
+		const char *this_key, *this_value;
+
+		if (this_key_len > XATTR_NAME_MAX ||
+		    /* key and data needs to fit in data */
+		    data_end - data < this_key_len + this_value_len) {
+			copied = -EFSCORRUPTED;
+			goto exit;
+		}
+
+		this_key = data;
+		this_value = data + this_key_len;
+		data += this_key_len + this_value_len;
 
 		if (size) {
-			if (size - copied < key_len + 1)
-				return -E2BIG;
+			if (size - copied < this_key_len + 1) {
+				copied = -E2BIG;
+				goto exit;
+			}
 
-			memcpy(names + copied, data, key_len);
-			names[copied + key_len] = '\0';
+			memcpy(names + copied, this_key, this_key_len);
+			names[copied + this_key_len] = '\0';
 		}
-		data += key_len + value_len;
-		copied += key_len + 1;
+
+		copied += this_key_len + 1;
 	}
+
+exit:
+	cfs_buf_put(&vdata_buf);
 
 	return copied;
 }
 
-int cfs_get_xattr(struct cfs_inode_data_s *inode_data, const char *name,
+int cfs_get_xattr(struct cfs_context_s *ctx,
+		  struct cfs_inode_data_s *inode_data, const char *name,
 		  void *value, size_t size)
 {
 	size_t name_len = strlen(name);
 	size_t n_xattrs = 0, i;
-	struct cfs_xattr_header_s *xattrs = inode_data->xattrs;
-	u8 *data;
+	struct cfs_xattr_header_s *xattrs;
+	u8 *data, *data_end;
+	struct cfs_buf vdata_buf = CFS_VDATA_BUF_INIT;
+	int res;
 
-	if (xattrs == 0)
+	if (inode_data->xattrs_len == 0)
 		return -ENODATA;
 
-	if (name_len > XATTR_NAME_MAX)
-		return -ENODATA;
+	/* xattrs_len basic size req was verified in cfs_init_inode_data */
 
-	/* The contents was verified in cfs_get_xattrs, so trust it here */
-	n_xattrs = xattrs->n_attr;
+	xattrs = cfs_get_vdata_buf(ctx, inode_data->xattrs_offset,
+				   inode_data->xattrs_len, &vdata_buf);
+	if (IS_ERR(xattrs))
+		return PTR_ERR(xattrs);
+
+	n_xattrs = cfs_u16_from_file(xattrs->n_attr);
+
+	/* Verify that array fits */
+	if (inode_data->xattrs_len < cfs_xattr_header_size(n_xattrs)) {
+		res = -EFSCORRUPTED;
+		goto exit;
+	}
 
 	data = ((u8 *)xattrs) + cfs_xattr_header_size(n_xattrs);
+	data_end = ((u8 *)xattrs) + inode_data->xattrs_len;
 
 	for (i = 0; i < n_xattrs; i++) {
-		char *this_key;
-		u8 *this_value;
-		uint16_t key_len = xattrs->attr[i].key_length;
-		uint16_t value_len = xattrs->attr[i].value_length;
+		const struct cfs_xattr_element_s *e = &xattrs->attr[i];
+		uint16_t this_key_len = cfs_u16_from_file(e->key_length);
+		uint16_t this_value_len = cfs_u16_from_file(e->value_length);
+		const char *this_key, *this_value;
 
-		this_key = (char *)data;
-		data += key_len;
+		if (this_key_len > XATTR_NAME_MAX ||
+		    /* key and data needs to fit in data */
+		    data_end - data < this_key_len + this_value_len) {
+			res = -EFSCORRUPTED;
+			goto exit;
+		}
 
-		this_value = data;
-		data += value_len;
+		this_key = data;
+		this_value = data + this_key_len;
+		data += this_key_len + this_value_len;
 
-		if (key_len != name_len)
-			continue;
-
-		if (memcmp(this_key, name, name_len) != 0)
+		if (this_key_len != name_len ||
+		    memcmp(this_key, name, name_len) != 0)
 			continue;
 
 		if (size > 0) {
-			if (size < value_len)
-				return -E2BIG;
-			memcpy(value, this_value, value_len);
+			if (size < this_value_len) {
+				res = -E2BIG;
+				goto exit;
+			}
+			memcpy(value, this_value, this_value_len);
 		}
 
-		return value_len;
+		res = this_value_len;
+		goto exit;
 	}
 
-	return -ENODATA;
+	res = -ENODATA;
+
+exit:
+	return res;
 }
 
 static struct cfs_dir_s *

--- a/kernel/cfs-reader.c
+++ b/kernel/cfs-reader.c
@@ -409,11 +409,11 @@ static bool cfs_validate_filename(const char *name, size_t name_len)
 	return true;
 }
 
-struct cfs_dir_s *cfs_dir_read_chunk_header(struct cfs_context_s *ctx,
-					    u32 payload_length, u64 index,
-					    u8 *chunk_buf,
-					    size_t chunk_buf_size,
-					    size_t max_n_chunks)
+static struct cfs_dir_s *cfs_dir_read_chunk_header(struct cfs_context_s *ctx,
+						   u32 payload_length,
+						   u64 index, u8 *chunk_buf,
+						   size_t chunk_buf_size,
+						   size_t max_n_chunks)
 {
 	size_t n_chunks, i;
 	struct cfs_dir_s *dir;

--- a/kernel/cfs-reader.c
+++ b/kernel/cfs-reader.c
@@ -20,6 +20,15 @@
 #include <linux/unaligned/packed_struct.h>
 #include <linux/sched/mm.h>
 
+struct cfs_buf {
+	struct page *page;
+	void *base;
+};
+#define CFS_VDATA_BUF_INIT                                                     \
+	{                                                                      \
+		NULL, NULL                                                     \
+	}
+
 static void cfs_buf_put(struct cfs_buf *buf)
 {
 	if (buf->page) {

--- a/kernel/cfs.c
+++ b/kernel/cfs.c
@@ -220,8 +220,8 @@ static int cfs_iterate(struct file *file, struct dir_context *ctx)
 			       ctx->pos - 2, cfs_iterate_cb, ctx);
 }
 
-struct dentry *cfs_lookup(struct inode *dir, struct dentry *dentry,
-			  unsigned int flags)
+static struct dentry *cfs_lookup(struct inode *dir, struct dentry *dentry,
+				 unsigned int flags)
 {
 	struct cfs_info *fsi = dir->i_sb->s_fs_info;
 	struct cfs_inode *cino = CFS_I(dir);

--- a/kernel/cfs.c
+++ b/kernel/cfs.c
@@ -823,17 +823,20 @@ static int cfs_getxattr(const struct xattr_handler *handler,
 			struct dentry *unused2, struct inode *inode,
 			const char *name, void *value, size_t size)
 {
+	struct cfs_info *fsi = inode->i_sb->s_fs_info;
 	struct cfs_inode *cino = CFS_I(inode);
 
-	return cfs_get_xattr(&cino->inode_data, name, value, size);
+	return cfs_get_xattr(&fsi->cfs_ctx, &cino->inode_data, name, value,
+			     size);
 }
 
 static ssize_t cfs_listxattr(struct dentry *dentry, char *names, size_t size)
 {
 	struct inode *inode = d_inode(dentry);
+	struct cfs_info *fsi = inode->i_sb->s_fs_info;
 	struct cfs_inode *cino = CFS_I(inode);
 
-	return cfs_list_xattrs(&cino->inode_data, names, size);
+	return cfs_list_xattrs(&fsi->cfs_ctx, &cino->inode_data, names, size);
 }
 
 static const struct file_operations cfs_file_operations = {

--- a/kernel/cfs.c
+++ b/kernel/cfs.c
@@ -382,7 +382,7 @@ static void cfs_put_super(struct super_block *sb)
 
 	if (fsi->root_mnt)
 		kern_unmount(fsi->root_mnt);
-	cfs_destroy_ctx(&fsi->cfs_ctx);
+	cfs_ctx_put(&fsi->cfs_ctx);
 	if (fsi->bases) {
 		for (i = 0; i < fsi->n_bases; i++)
 			fput(fsi->bases[i]);
@@ -563,7 +563,7 @@ fail:
 	}
 	if (root_mnt)
 		kern_unmount(root_mnt);
-	cfs_destroy_ctx(&fsi->cfs_ctx);
+	cfs_ctx_put(&fsi->cfs_ctx);
 	return ret;
 }
 


### PR DESCRIPTION
This has some cleanup, and then switches the xattr code to directly use memory from the page cache. This means we don't have to copy this memory for each inode, slimming memory use and sharing memory for caching de-duplicated xattr data.