### PR TITLE
Fix warnings reported by checkpatch

### DIFF
--- a/kernel/cfs-internals.h
+++ b/kernel/cfs-internals.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0 */
 #ifndef _CFS_INTERNALS_H
 #define _CFS_INTERNALS_H
 

--- a/kernel/cfs-reader.c
+++ b/kernel/cfs-reader.c
@@ -284,21 +284,19 @@ struct cfs_inode_s *cfs_get_ino_index(struct cfs_context_s *ctx, u64 index,
 	if (inode_size > sizeof(buffer))
 		return ERR_PTR(-EFSCORRUPTED);
 
-	if (CFS_INODE_FLAG_CHECK(ino->flags, PAYLOAD)) {
+	if (CFS_INODE_FLAG_CHECK(ino->flags, PAYLOAD))
 		ino->payload_length = cfs_read_u32(&data);
-	} else {
+	else
 		ino->payload_length = 0;
-	}
 
-	if (CFS_INODE_FLAG_CHECK(ino->flags, MODE)) {
+	if (CFS_INODE_FLAG_CHECK(ino->flags, MODE))
 		ino->st_mode = cfs_read_u32(&data);
-	} else {
+	else
 		ino->st_mode = CFS_INODE_DEFAULT_MODE;
-	}
 
-	if (CFS_INODE_FLAG_CHECK(ino->flags, NLINK)) {
+	if (CFS_INODE_FLAG_CHECK(ino->flags, NLINK))
 		ino->st_nlink = cfs_read_u32(&data);
-	} else {
+	else {
 		if ((ino->st_mode & S_IFMT) == S_IFDIR)
 			ino->st_nlink = CFS_INODE_DEFAULT_NLINK_DIR;
 		else
@@ -313,11 +311,10 @@ struct cfs_inode_s *cfs_get_ino_index(struct cfs_context_s *ctx, u64 index,
 		ino->st_gid = CFS_INODE_DEFAULT_UIDGID;
 	}
 
-	if (CFS_INODE_FLAG_CHECK(ino->flags, RDEV)) {
+	if (CFS_INODE_FLAG_CHECK(ino->flags, RDEV))
 		ino->st_rdev = cfs_read_u32(&data);
-	} else {
+	else
 		ino->st_rdev = CFS_INODE_DEFAULT_RDEV;
-	}
 
 	if (CFS_INODE_FLAG_CHECK(ino->flags, TIMES)) {
 		ino->st_mtim.tv_sec = cfs_read_u64(&data);
@@ -335,15 +332,13 @@ struct cfs_inode_s *cfs_get_ino_index(struct cfs_context_s *ctx, u64 index,
 		ino->st_ctim.tv_nsec = 0;
 	}
 
-	if (CFS_INODE_FLAG_CHECK(ino->flags, LOW_SIZE)) {
+	if (CFS_INODE_FLAG_CHECK(ino->flags, LOW_SIZE))
 		ino->st_size = cfs_read_u32(&data);
-	} else {
+	else
 		ino->st_size = 0;
-	}
 
-	if (CFS_INODE_FLAG_CHECK(ino->flags, HIGH_SIZE)) {
+	if (CFS_INODE_FLAG_CHECK(ino->flags, HIGH_SIZE))
 		ino->st_size += (u64)cfs_read_u32(&data) << 32;
-	}
 
 	if (CFS_INODE_FLAG_CHECK(ino->flags, XATTRS)) {
 		ino->xattrs.off = cfs_read_u64(&data);
@@ -867,9 +862,8 @@ static int cfs_dir_lookup_in_chunk(const char *name, size_t name_len,
 
 	// This should not happen in a valid fs, and if it does we don't know if
 	// the name is before or after the chunk.
-	if (n_dentries == 0) {
+	if (n_dentries == 0)
 		return -EFSCORRUPTED;
-	}
 
 	start_dentry = 0;
 	end_dentry = n_dentries - 1;
@@ -891,11 +885,10 @@ static int cfs_dir_lookup_in_chunk(const char *name, size_t name_len,
 			return 0;
 		}
 
-		if (cmp > 0) {
+		if (cmp > 0)
 			start_dentry = mid_dentry + 1;
-		} else {
+		else
 			end_dentry = mid_dentry - 1;
-		}
 	}
 
 	return cmp > 0 ? AFTER_CHUNK : BEFORE_CHUNK;
@@ -918,9 +911,8 @@ int cfs_dir_lookup(struct cfs_context_s *ctx, u64 index,
 		return 0;
 
 	chunks = cfs_dir_get_chunk_info(ctx, index, inode_data, &chunks_buf);
-	if (IS_ERR(chunks)) {
+	if (IS_ERR(chunks))
 		return PTR_ERR(chunks);
-	}
 
 	start_chunk = 0;
 	end_chunk = n_chunks - 1;

--- a/kernel/cfs-reader.c
+++ b/kernel/cfs-reader.c
@@ -566,10 +566,8 @@ fail:
 void cfs_inode_data_put(struct cfs_inode_data_s *inode_data)
 {
 	inode_data->n_dir_chunks = 0;
-	if (inode_data->path_payload) {
-		kfree(inode_data->path_payload);
-		inode_data->path_payload = NULL;
-	}
+	kfree(inode_data->path_payload);
+	inode_data->path_payload = NULL;
 }
 
 ssize_t cfs_list_xattrs(struct cfs_context_s *ctx,
@@ -844,8 +842,7 @@ int cfs_dir_iterate(struct cfs_context_s *ctx, u64 index,
 
 	res = 0;
 exit:
-	if (chunks_buf)
-		kfree(chunks_buf);
+	kfree(chunks_buf);
 	cfs_buf_put(&vdata_buf);
 	return res;
 }
@@ -958,8 +955,7 @@ int cfs_dir_lookup(struct cfs_context_s *ctx, u64 index,
 	res = 0;
 
 exit:
-	if (chunks_buf)
-		kfree(chunks_buf);
+	kfree(chunks_buf);
 	cfs_buf_put(&vdata_buf);
 	return res;
 }

--- a/kernel/cfs-reader.c
+++ b/kernel/cfs-reader.c
@@ -443,6 +443,7 @@ static struct cfs_dir_s *cfs_dir_read_chunk_header(struct cfs_context_s *ctx,
 	/* Verify data (up to max_n_chunks) */
 	for (i = 0; i < max_n_chunks; i++) {
 		struct cfs_dir_chunk_s *chunk = &dir->chunks[i];
+
 		chunk->n_dentries = cfs_u16_from_file(chunk->n_dentries);
 		chunk->chunk_size = cfs_u16_from_file(chunk->chunk_size);
 		chunk->chunk_offset = cfs_u64_from_file(chunk->chunk_offset);

--- a/kernel/cfs-reader.c
+++ b/kernel/cfs-reader.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0
 /*
  * composefs
  *

--- a/kernel/cfs.c
+++ b/kernel/cfs.c
@@ -623,9 +623,8 @@ static int cfs_open_file(struct inode *inode, struct file *file)
 		real_file = open_base_file(fsi, inode, file);
 	}
 
-	if (IS_ERR(real_file)) {
+	if (IS_ERR(real_file))
 		return PTR_ERR(real_file);
-	}
 
 	/* If metadata records a digest for the file, ensure it is there and correct before using the contents */
 	if (cino->inode_data.has_digest && !fsi->noverity) {

--- a/kernel/cfs.c
+++ b/kernel/cfs.c
@@ -330,7 +330,7 @@ static int cfs_show_options(struct seq_file *m, struct dentry *root)
 	struct cfs_info *fsi = root->d_sb->s_fs_info;
 
 	if (fsi->noverity)
-		seq_printf(m, ",noverity");
+		seq_puts(m, ",noverity");
 	if (fsi->base_path)
 		seq_printf(m, ",basedir=%s", fsi->base_path);
 	if (fsi->has_digest) {

--- a/kernel/cfs.c
+++ b/kernel/cfs.c
@@ -280,6 +280,7 @@ static void digest_to_string(const uint8_t *digest, char *buf)
 
 	for (i = 0, j = 0; i < SHA256_DIGEST_SIZE; i++, j += 2) {
 		uint8_t byte = digest[i];
+
 		buf[j] = hexchars[byte >> 4];
 		buf[j + 1] = hexchars[byte & 0xF];
 	}
@@ -335,6 +336,7 @@ static int cfs_show_options(struct seq_file *m, struct dentry *root)
 		seq_printf(m, ",basedir=%s", fsi->base_path);
 	if (fsi->has_digest) {
 		char buf[SHA256_DIGEST_SIZE * 2 + 1];
+
 		digest_to_string(fsi->digest, buf);
 		seq_printf(m, ",digest=%s", buf);
 	}
@@ -631,6 +633,7 @@ static int cfs_open_file(struct inode *inode, struct file *file)
 		u8 verity_digest[FS_VERITY_MAX_DIGEST_SIZE];
 		enum hash_algo verity_algo;
 		int res;
+
 		res = fsverity_get_digest(d_inode(real_file->f_path.dentry),
 					  verity_digest, &verity_algo);
 		if (res < 0) {

--- a/kernel/cfs.c
+++ b/kernel/cfs.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-2.0
 /*
  * composefs
  *

--- a/kernel/cfs.c
+++ b/kernel/cfs.c
@@ -174,8 +174,7 @@ static struct inode *cfs_make_inode(struct cfs_context_s *ctx,
 fail:
 	if (inode)
 		iput(inode);
-	if (xattrs)
-		kfree(xattrs);
+	kfree(xattrs);
 	cfs_inode_data_put(&inode_data);
 	return ERR_PTR(ret);
 }
@@ -391,8 +390,7 @@ static void cfs_put_super(struct super_block *sb)
 			fput(fsi->bases[i]);
 		kfree(fsi->bases);
 	}
-	if (fsi->base_path)
-		kfree(fsi->base_path);
+	kfree(fsi->base_path);
 
 	kfree(fsi);
 }

--- a/kernel/cfs.h
+++ b/kernel/cfs.h
@@ -1,3 +1,4 @@
+/* SPDX-License-Identifier: GPL-2.0 */
 /*
  * composefs
  *

--- a/kernel/cfs.h
+++ b/kernel/cfs.h
@@ -159,14 +159,14 @@ struct cfs_inode_s {
 	/* Optional data: (selected by flags) */
 
 	/* This is the size of the type specific data that comes directly after
-	   the inode in the file. Of this type:
-	   *
-	   * directory: cfs_dir_s
-	   * regular file: the backing filename
-	   * symlink: the target link
-	   *
-	   * Canonically payload_length is 0 for empty dir/file/symlink.
-	   */
+	 * the inode in the file. Of this type:
+	 *
+	 * directory: cfs_dir_s
+	 * regular file: the backing filename
+	 * symlink: the target link
+	 *
+	 * Canonically payload_length is 0 for empty dir/file/symlink.
+	 */
 	u32 payload_length;
 
 	u32 st_mode; /* File type and mode.  */

--- a/kernel/cfs.h
+++ b/kernel/cfs.h
@@ -89,9 +89,8 @@ static inline int cfs_digest_from_payload(const char *payload,
 			return -1; /* Too long */
 
 		digit = cfs_xdigit_value(*p);
-		if (digit == -1) {
+		if (digit == -1)
 			return -1; /* Not hex digit */
-		}
 
 		n_nibbles++;
 		if ((n_nibbles % 2) == 0) {

--- a/kernel/cfs.h
+++ b/kernel/cfs.h
@@ -109,7 +109,7 @@ static inline int cfs_digest_from_payload(const char *payload,
 struct cfs_vdata_s {
 	u64 off;
 	u32 len;
-} __attribute__((packed));
+} __packed;
 
 struct cfs_header_s {
 	u8 version;
@@ -121,7 +121,7 @@ struct cfs_header_s {
 	u64 root_inode;
 
 	u64 unused3[2];
-} __attribute__((packed));
+} __packed;
 
 enum cfs_inode_flags {
 	CFS_INODE_FLAGS_NONE = 0,
@@ -208,18 +208,18 @@ struct cfs_dentry_s {
 	u8 d_type;
 	u8 name_len;
 	u16 name_offset;
-} __attribute__((packed));
+} __packed;
 
 struct cfs_dir_chunk_s {
 	u16 n_dentries;
 	u16 chunk_size;
 	u64 chunk_offset;
-} __attribute__((packed));
+} __packed;
 
 struct cfs_dir_s {
 	u32 n_chunks;
 	struct cfs_dir_chunk_s chunks[];
-} __attribute__((packed));
+} __packed;
 
 #define cfs_dir_size(_n_chunks)                                                \
 	(sizeof(struct cfs_dir_s) +                                            \
@@ -229,12 +229,12 @@ struct cfs_dir_s {
 struct cfs_xattr_element_s {
 	u16 key_length;
 	u16 value_length;
-} __attribute__((packed));
+} __packed;
 
 struct cfs_xattr_header_s {
 	u16 n_attr;
 	struct cfs_xattr_element_s attr[0];
-} __attribute__((packed));
+} __packed;
 
 #define cfs_xattr_header_size(_n_element)                                      \
 	(sizeof(struct cfs_xattr_header_s) +                                   \


### PR DESCRIPTION
With this series I now get:
```
$ checkpatch.pl --file cfs.c --file cfs-reader.c --file cfs.h --file cfs-internals.h
-----
cfs.c
-----
WARNING: LINUX_VERSION_CODE should be avoided, code should be for the version to which it is merged
#350: FILE: cfs.c:350:
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 18, 0))

WARNING: Comparisons should place the constant on the right side of the test
#350: FILE: cfs.c:350:
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 18, 0))

total: 0 errors, 2 warnings, 923 lines checked

NOTE: For some of the reported defects, checkpatch may be able to
      mechanically convert to the typical style using --fix or --fix-inplace.

cfs.c has style problems, please review.
------------
cfs-reader.c
------------
total: 0 errors, 0 warnings, 961 lines checked

cfs-reader.c has no obvious style problems and is ready for submission.
-----
cfs.h
-----
total: 0 errors, 0 warnings, 243 lines checked

cfs.h has no obvious style problems and is ready for submission.
---------------
cfs-internals.h
---------------
total: 0 errors, 0 warnings, 69 lines checked

cfs-internals.h has no obvious style problems and is ready for submission.

NOTE: If any of the errors are false positives, please report
      them to the maintainer, see CHECKPATCH in MAINTAINERS.
```

I don't think we can fix the version checks atm while out-of-tree.