### PR TITLE
lib: Report error path in lcfs_build()

### DIFF
--- a/libcomposefs/lcfs-writer.h
+++ b/libcomposefs/lcfs-writer.h
@@ -93,9 +93,8 @@ int lcfs_node_set_fsverity_from_content(struct lcfs_node_s *node, void *file,
 
 int lcfs_node_set_fsverity_from_fd(struct lcfs_node_s *node, int fd);
 
-struct lcfs_node_s *lcfs_build(struct lcfs_node_s *parent, int dirfd,
-			       const char *fname, const char *name,
-			       int buildflags);
+struct lcfs_node_s *lcfs_build(int dirfd, const char *fname, const char *name,
+			       int buildflags, char **failed_path_out);
 
 int lcfs_write_to(struct lcfs_node_s *root, void *file, lcfs_write_cb write_cb,
 		  uint8_t *digest_out);

--- a/tools/mkcomposefs.c
+++ b/tools/mkcomposefs.c
@@ -430,6 +430,7 @@ int main(int argc, char **argv)
 	uint8_t digest[LCFS_DIGEST_SIZE];
 	int opt;
 	FILE *out_file;
+	char *failed_path;
 
 	while ((opt = getopt_long(argc, argv, ":CR", longopts, NULL)) != -1) {
 		switch (opt) {
@@ -506,9 +507,9 @@ int main(int argc, char **argv)
 			      "Failed to open output file");
 	}
 
-	root = lcfs_build(NULL, AT_FDCWD, dir_path, "", buildflags);
+	root = lcfs_build(AT_FDCWD, dir_path, "", buildflags, &failed_path);
 	if (root == NULL)
-		error(EXIT_FAILURE, errno, "load current directory node");
+		error(EXIT_FAILURE, errno, "Error accessing %s", failed_path);
 
 	if (absolute_path) {
 		pathbuf[0] = '\0';


### PR DESCRIPTION
Without this it was a pain to figure out why mkcomposefs failed.

Also, this drops the unused "parent" arg to lcfs_build().