### PR TITLE
kernel: Fix stating empty files

### DIFF
--- a/kernel/cfs-reader.c
+++ b/kernel/cfs-reader.c
@@ -524,7 +524,7 @@ int cfs_init_inode_data(struct cfs_context_s *ctx, struct cfs_inode_s *ino,
 	}
 
 	if ((ino->st_mode & S_IFMT) == S_IFLNK ||
-	    ((ino->st_mode & S_IFMT) == S_IFREG && ino->payload_length >= 0)) {
+	    ((ino->st_mode & S_IFMT) == S_IFREG && ino->payload_length > 0)) {
 		path_payload = cfs_dup_payload_path(ctx, ino, index);
 		if (IS_ERR(path_payload)) {
 			ret = PTR_ERR(path_payload);


### PR DESCRIPTION
Empty files have zero payload length, and no path, so the check for loading the poayload path should be payload_length > 0, not >= 0.

Signed-off-by: Alexander Larsson <alexl@redhat.com>