### PR TITLE
Change when we require fs-verity

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ Once it is loaded, it can be used as:
 Mount options:
 
 - `basedir`: is the directory to use as a base when resolving relative content paths.
-- `noverity`: Don't verify that target files have the right fs-verity digest. Useful if the fs doesn't support fs-verity but the image has digests enabled.
-- `digest`: A fs-verity sha256 digest that the image file must match.
+- `verity_check=0,1,2`: When to verify backing file fs-verity: 0 == never, 1 == if specified in image, 2 == always and require it in image.
+- `digest`: A fs-verity sha256 digest that the image file must match. If set, `verity_check` defaults to 2.
 
 ## SELinux issues
 

--- a/kernel/Documentation/filesystems/composefs.rst
+++ b/kernel/Documentation/filesystems/composefs.rst
@@ -114,8 +114,8 @@ Mount options
 =============
 
 `basedir`: A colon separated list of directories to use as a base when resolving relative content paths.
-`digest`: A fs-verity sha256 digest that the descriptor file must match.
-`noverity`: Don't verify that target files have the right fs-verity digest. Useful if the backing filesystem doesn't support fs-verity but the descriptor contains digests.
+`verity_check=[0,1,2]`: When to verify backing file fs-verity: 0 == never, 1 == if specified in image, 2 == always and require it in image.
+`digest`: A fs-verity sha256 digest that the descriptor file must match. If set, `verity_check` defaults to 2.
 
 
 Filesystem format


### PR DESCRIPTION
This changes when we verify fs-verity. The goal is to have it easy to create fs-verity enabled images with `mkcomposefs --digest-store=`, but also make it easy to consume them without requiring you to explicitly disable verity.

The new setup is a single option verity_check=[0,1,2]. 0 means we never require verity. 1 means we veritfy backing file fs-verity if the image specifies a verity digest. 2 additionally means we require the image to specify a digest for all non-empty files.

Fixes https://github.com/containers/composefs/issues/74

Signed-off-by: Alexander Larsson <alexl@redhat.com>