### PR TITLE
Change to a simpler fixed size inode format

### DIFF
--- a/kernel/Documentation/filesystems/composefs.rst
+++ b/kernel/Documentation/filesystems/composefs.rst
@@ -130,36 +130,24 @@ digest
 Filesystem format
 =================
 
-The format of the descriptor contains three sections: header,
+The format of the descriptor contains three sections: superblock,
 inodes and variable data. All data in the file is stored in
 little-endian form.
 
-The header starts at the beginning of the file and contains version,
-magic value, offsets to the variable data and the root inode nr.
+The superblock starts at the beginning of the file and contains
+version, magic value, and offsets to the variable data section.
 
-The inode section starts at a fixed location right after the
-header. It is a array of inode data, where for each inode there is
-first a variable length chunk and then a fixed size chunk. An inode nr
-is the offset in the inode data to the start of the fixed chunk.
-
-The fixed inode chunk starts with a flag that tells what parts of the
-inode are stored in the file (meaning it is only the maximal size that
-is fixed). After that the various inode attributes are serialized in
-order, such as mode, ownership, xattrs, and payload length. The
-latter attribute gives the size of the variable chunk.
-
-The inode variable chunk contains different things depending on the
-file type.  For regular files it is the backing filename. For symlinks
-it is the symlink target. For directories it is a list of references to
-dentries, stored in chunks of maximum 4k. The dentry chunks themselves
-are stored in the variable data section.
+The inode table starts at a fixed location right after the
+header. It is a array of fixed size inode data. The first inode
+is the root inode, and inode numbers are index into this array.
 
 The variable data section is stored after the inode section, and you
-can find it from the offset in the header. It contains dentries and
-Xattrs data. The xattrs are referred to by offset and size in the
-xattr attribute in the inode data. Each xattr data can be used by many
-inodes in the filesystem. The variable data chunks are all smaller than
-a page (4K) and are padded to not span pages.
+can find it from the offset in the header. It contains paths, digests,
+dirents and Xattrs data. The xattrs are referred to by offset and size
+in the xattr attribute in the inode data. Each xattr data can be used
+by many inodes in the filesystem.
+
+For more details, see cfs.h.
 
 Tools
 =====

--- a/kernel/cfs-internals.h
+++ b/kernel/cfs-internals.h
@@ -24,8 +24,10 @@ struct cfs_inode_data_s {
 };
 
 struct cfs_context_s {
-	struct cfs_header_s header;
+	struct cfs_superblock superblock;
 	struct file *descriptor;
+	u64 data_offset;
+	u64 root_inode;
 
 	u64 descriptor_len;
 };

--- a/kernel/cfs-internals.h
+++ b/kernel/cfs-internals.h
@@ -38,7 +38,7 @@ void cfs_ctx_put(struct cfs_context *ctx);
 
 void cfs_inode_extra_data_put(struct cfs_inode_extra_data *inode_data);
 
-int cfs_init_inode(struct cfs_context *ctx, u64 index,
+int cfs_init_inode(struct cfs_context *ctx, u32 inode_num,
                    struct inode *inode,
                    struct cfs_inode_extra_data *data);
 

--- a/kernel/cfs-internals.h
+++ b/kernel/cfs-internals.h
@@ -37,12 +37,12 @@ void cfs_ctx_put(struct cfs_context *ctx);
 
 void cfs_inode_extra_data_put(struct cfs_inode_extra_data *inode_data);
 
-int cfs_init_inode(struct cfs_context *ctx, u32 inode_num,
-                   struct inode *inode,
-                   struct cfs_inode_extra_data *data);
+int cfs_init_inode(struct cfs_context *ctx, u32 inode_num, struct inode *inode,
+		   struct cfs_inode_extra_data *data);
 
-ssize_t cfs_list_xattrs(struct cfs_context *ctx, struct cfs_inode_extra_data *inode_data,
-			char *names, size_t size);
+ssize_t cfs_list_xattrs(struct cfs_context *ctx,
+			struct cfs_inode_extra_data *inode_data, char *names,
+			size_t size);
 int cfs_get_xattr(struct cfs_context *ctx, struct cfs_inode_extra_data *inode_data,
 		  const char *name, void *value, size_t size);
 

--- a/kernel/cfs-internals.h
+++ b/kernel/cfs-internals.h
@@ -9,7 +9,7 @@
 
 #define CFS_N_PRELOAD_DIR_CHUNKS 4
 
-struct cfs_inode_data_s {
+struct cfs_inode_extra_data {
 	char *path_payload; /* Real pathname for files, target for symlinks */
 
 	u64 xattrs_offset;
@@ -22,7 +22,7 @@ struct cfs_inode_data_s {
 	u8 digest[SHA256_DIGEST_SIZE]; /* fs-verity digest */
 };
 
-struct cfs_context_s {
+struct cfs_context {
 	struct cfs_superblock superblock;
 	struct file *descriptor;
 	u64 data_offset;
@@ -32,35 +32,30 @@ struct cfs_context_s {
 };
 
 int cfs_init_ctx(const char *descriptor_path, const u8 *required_digest,
-		 struct cfs_context_s *ctx);
+		 struct cfs_context *ctx);
 
-void cfs_ctx_put(struct cfs_context_s *ctx);
+void cfs_ctx_put(struct cfs_context *ctx);
 
-void cfs_inode_data_put(struct cfs_inode_data_s *inode_data);
+void cfs_inode_extra_data_put(struct cfs_inode_extra_data *inode_data);
 
-struct cfs_inode_s *cfs_get_root_ino(struct cfs_context_s *ctx,
-				     struct cfs_inode_s *ino_buf, u64 *index);
+int cfs_init_inode(struct cfs_context *ctx, u64 index,
+                   struct inode *inode,
+                   struct cfs_inode_extra_data *data);
 
-struct cfs_inode_s *cfs_get_ino_index(struct cfs_context_s *ctx, u64 index,
-				      struct cfs_inode_s *buffer);
-
-int cfs_init_inode_data(struct cfs_context_s *ctx, struct cfs_inode_s *ino,
-			u64 index, struct cfs_inode_data_s *data);
-
-ssize_t cfs_list_xattrs(struct cfs_context_s *ctx, struct cfs_inode_data_s *inode_data,
+ssize_t cfs_list_xattrs(struct cfs_context *ctx, struct cfs_inode_extra_data *inode_data,
 			char *names, size_t size);
-int cfs_get_xattr(struct cfs_context_s *ctx, struct cfs_inode_data_s *inode_data,
+int cfs_get_xattr(struct cfs_context *ctx, struct cfs_inode_extra_data *inode_data,
 		  const char *name, void *value, size_t size);
 
 typedef bool (*cfs_dir_iter_cb)(void *private, const char *name, int namelen,
 				u64 ino, unsigned int dtype);
 
-int cfs_dir_iterate(struct cfs_context_s *ctx, u64 index,
-		    struct cfs_inode_data_s *inode_data, loff_t first,
+int cfs_dir_iterate(struct cfs_context *ctx, u64 index,
+		    struct cfs_inode_extra_data *inode_data, loff_t first,
 		    cfs_dir_iter_cb cb, void *private);
 
-int cfs_dir_lookup(struct cfs_context_s *ctx, u64 index,
-		   struct cfs_inode_data_s *inode_data, const char *name,
+int cfs_dir_lookup(struct cfs_context *ctx, u64 index,
+		   struct cfs_inode_extra_data *inode_data, const char *name,
 		   size_t name_len, u64 *index_out);
 
 #endif

--- a/kernel/cfs-internals.h
+++ b/kernel/cfs-internals.h
@@ -23,9 +23,8 @@ struct cfs_inode_extra_data {
 };
 
 struct cfs_context {
-	struct cfs_superblock superblock;
 	struct file *descriptor;
-	u64 data_offset;
+	u64 vdata_offset;
 	u64 root_inode;
 
 	u64 descriptor_len;

--- a/kernel/cfs-internals.h
+++ b/kernel/cfs-internals.h
@@ -12,11 +12,12 @@
 struct cfs_inode_data_s {
 	u32 payload_length;
 	char *path_payload; /* Real pathname for files, target for symlinks */
-	u32 n_dir_chunks;
-	struct cfs_dir_chunk_s preloaded_dir_chunks[CFS_N_PRELOAD_DIR_CHUNKS];
 
 	u64 xattrs_offset;
 	u32 xattrs_len;
+
+	u64 dirents_offset;
+	u32 dirents_len;
 
 	bool has_digest;
 	u8 digest[SHA256_DIGEST_SIZE]; /* fs-verity digest */

--- a/kernel/cfs-internals.h
+++ b/kernel/cfs-internals.h
@@ -10,7 +10,6 @@
 #define CFS_N_PRELOAD_DIR_CHUNKS 4
 
 struct cfs_inode_data_s {
-	u32 payload_length;
 	char *path_payload; /* Real pathname for files, target for symlinks */
 
 	u64 xattrs_offset;

--- a/kernel/cfs-reader.c
+++ b/kernel/cfs-reader.c
@@ -27,16 +27,21 @@
 
 #define CFS_BUF_PREALLOC_SIZE 4
 
+/* Check if the element, which is supposed to be offset from section_start
+ * actually fits in the section starting at section_start ending at section_end,
+ * and doesn't wrap.
+ */
 static bool cfs_is_in_section(u64 section_start, u64 section_end,
-			      u64 element_start, u64 element_size)
+			      u64 element_offset, u64 element_size)
 {
 	u64 element_end;
+	u64 element_start;
 
+	element_start = section_start + element_offset;
 	if (element_start < section_start || element_start >= section_end)
 		return false;
 
 	element_end = element_start + element_size;
-	/* Avoid potential overflow here */
 	if (element_end < element_start || element_end > section_end)
 		return false;
 

--- a/kernel/cfs-reader.c
+++ b/kernel/cfs-reader.c
@@ -14,14 +14,26 @@
 #include <linux/pagemap.h>
 #include <linux/vmalloc.h>
 
-#define CFS_BUF_MAXPAGES 256 /* arbitrary limit to avoid extreme memory use */
+/* When mapping buffers via page arrays this is an "arbitrary" limit
+ * to ensure we're not ballooning memory use for the page array and
+ * mapping. On a 4k page, 64bit machine this limit will make the page
+ * array fit in one page, and will allow a mapping of 2MB. When
+ * applied to e.g. dirents this will allow more than 27000 filenames
+ * of length 64, which seems ok. If we need to support more, at that
+ * point we really should fall back to an approach that maps
+ * incrementally.
+ */
+#define CFS_BUF_MAXPAGES 512
+
 #define CFS_BUF_PREALLOC_SIZE 4
 
 struct cfs_buf {
 	struct page **pages;
 	size_t n_pages;
 	void *base;
-	struct page *prealloc[CFS_BUF_PREALLOC_SIZE]; /* No need for allocation for small buffers */
+
+	/* Used as "pages" above to avoid allocation for small buffers */
+	struct page *prealloc[CFS_BUF_PREALLOC_SIZE];
 };
 
 static void cfs_buf_put(struct cfs_buf *buf)

--- a/kernel/cfs.c
+++ b/kernel/cfs.c
@@ -262,17 +262,11 @@ static struct inode *cfs_alloc_inode(struct super_block *sb)
 	return &cino->vfs_inode;
 }
 
-static void cfs_destroy_inode(struct inode *inode)
-{
-	struct cfs_inode *cino = CFS_I(inode);
-
-	cfs_inode_extra_data_put(&cino->inode_data);
-}
-
 static void cfs_free_inode(struct inode *inode)
 {
 	struct cfs_inode *cino = CFS_I(inode);
 
+	cfs_inode_extra_data_put(&cino->inode_data);
 	kmem_cache_free(cfs_inode_cachep, cino);
 }
 
@@ -315,7 +309,6 @@ static const struct super_operations cfs_ops = {
 	.drop_inode = generic_delete_inode,
 	.show_options = cfs_show_options,
 	.put_super = cfs_put_super,
-	.destroy_inode = cfs_destroy_inode,
 	.alloc_inode = cfs_alloc_inode,
 	.free_inode = cfs_free_inode,
 };

--- a/kernel/cfs.c
+++ b/kernel/cfs.c
@@ -28,10 +28,11 @@ MODULE_AUTHOR("Giuseppe Scrivano <gscrivan@redhat.com>");
 
 /* Backing file fs-verity check policy, ordered in strictness */
 enum cfs_verity_policy {
-	CFS_VERITY_CHECK_NONE = 0,         /* Never verify digest */
+	CFS_VERITY_CHECK_NONE = 0, /* Never verify digest */
 	CFS_VERITY_CHECK_IF_SPECIFIED = 1, /* Verify if specified in image */
-	CFS_VERITY_CHECK_REQUIRED = 2,     /* Always verify, fail if not if specified in image */
+	CFS_VERITY_CHECK_REQUIRED = 2, /* Always verify, fail if not if specified in image */
 };
+
 #define CFS_VERITY_CHECK_MAX_POLICY 2
 
 struct cfs_info {
@@ -97,9 +98,8 @@ static unsigned int cfs_split_basedirs(char *str)
 	return ctr;
 }
 
-static struct inode *cfs_make_inode(struct cfs_context *ctx,
-				    struct super_block *sb, ino_t ino_num,
-				    const struct inode *dir)
+static struct inode *cfs_make_inode(struct cfs_context *ctx, struct super_block *sb,
+				    ino_t ino_num, const struct inode *dir)
 {
 	struct inode *inode;
 	struct cfs_inode *cino;
@@ -524,7 +524,8 @@ static int cfs_open_file(struct inode *inode, struct file *file)
 		return 0;
 	}
 
-	if (fsi->verity_check >= CFS_VERITY_CHECK_REQUIRED && !cino->inode_data.has_digest) {
+	if (fsi->verity_check >= CFS_VERITY_CHECK_REQUIRED &&
+	    !cino->inode_data.has_digest) {
 		pr_warn("WARNING: composefs image file '%pD' specified no fs-verity digest\n",
 			file);
 		return -EIO;
@@ -538,7 +539,8 @@ static int cfs_open_file(struct inode *inode, struct file *file)
 	/* If metadata records a digest for the file, ensure it is there
 	 * and correct before using the contents.
 	 */
-	if (cino->inode_data.has_digest && fsi->verity_check >= CFS_VERITY_CHECK_IF_SPECIFIED) {
+	if (cino->inode_data.has_digest &&
+	    fsi->verity_check >= CFS_VERITY_CHECK_IF_SPECIFIED) {
 		u8 verity_digest[FS_VERITY_MAX_DIGEST_SIZE];
 		enum hash_algo verity_algo;
 		int res;

--- a/kernel/cfs.c
+++ b/kernel/cfs.c
@@ -30,7 +30,7 @@ MODULE_AUTHOR("Giuseppe Scrivano <gscrivan@redhat.com>");
 enum cfs_verity_policy {
 	CFS_VERITY_CHECK_NONE = 0, /* Never verify digest */
 	CFS_VERITY_CHECK_IF_SPECIFIED = 1, /* Verify if specified in image */
-	CFS_VERITY_CHECK_REQUIRED = 2, /* Always verify, fail if not if specified in image */
+	CFS_VERITY_CHECK_REQUIRED = 2, /* Always verify, fail if not specified in image */
 };
 
 #define CFS_VERITY_CHECK_MAX_POLICY 2

--- a/kernel/cfs.h
+++ b/kernel/cfs.h
@@ -35,9 +35,9 @@
  *  |  digests              |
  *  +-----------------------+
  *
- *  The superblock is at the start of the file, and the inode table
- *  directly follows it. The variable data section found via
- *  vdata_offset and all sections are 32bit aligned. All data is
+ * The superblock is at the start of the file, and the inode table
+ * directly follows it. The variable data section found via
+ * vdata_offset and all sections are 32bit aligned. All data is
  *  little endian.
  *
  * The inode table is a table of fixed size cfs_inode_data elements.
@@ -71,56 +71,63 @@
 #define CFS_ROOT_INO 0
 
 struct cfs_superblock {
-	__le32 version;      /* CFS_VERSION */
-	__le32 magic;        /* CFS_MAGIC */
-	__le64 vdata_offset; /* Offset of the variable data data
-				section from start of file */
+	__le32 version; /* CFS_VERSION */
+	__le32 magic; /* CFS_MAGIC */
 
-	__le64 unused[2];    /* For future use */
+	/* Offset of the variable data section from start of file */
+	__le64 vdata_offset;
+
+	__le64 unused[2]; /* For future use */
 };
 
 struct cfs_vdata {
-	__le64 off;  /* Offset into variable data section */
+	__le64 off; /* Offset into variable data section */
 	__le32 len;
 };
 
 struct cfs_inode_data {
-	__le32 st_mode;      /* File type and mode.  */
-	__le32 st_nlink;     /* Number of hard links, only for regular files.  */
-	__le32 st_uid;       /* User ID of owner.  */
-	__le32 st_gid;       /* Group ID of owner.  */
-	__le32 st_rdev;      /* Device ID (if special file).  */
-	__le64 st_size;      /* Size of file */
+	__le32 st_mode; /* File type and mode.  */
+	__le32 st_nlink; /* Number of hard links, only for regular files.  */
+	__le32 st_uid; /* User ID of owner.  */
+	__le32 st_gid; /* Group ID of owner.  */
+	__le32 st_rdev; /* Device ID (if special file).  */
+	__le64 st_size; /* Size of file */
 	__le64 st_mtim_sec;
 	__le32 st_mtim_nsec;
 	__le64 st_ctim_sec;
 	__le32 st_ctim_nsec;
 
 	/* References to variable storage area: */
-	struct cfs_vdata variable_data; /* per-type variable data:
-					   S_IFDIR: dirents
-					   S_IFREG: backing file pathnem
-					   S_IFLNLK; symlink target */
+
+	/* per-type variable data:
+	 * S_IFDIR: dirents
+	 * S_IFREG: backing file pathnem
+	 * S_IFLNLK; symlink target
+	 */
+	struct cfs_vdata variable_data;
+
 	struct cfs_vdata xattrs;
-	struct cfs_vdata digest;  /* Expected fs-verity digest of backing file */
+	struct cfs_vdata digest; /* Expected fs-verity digest of backing file */
 };
 
 struct cfs_dirent {
-	__le32 inode_num;    /* Index in inode table */
-	__le32 name_offset;  /* Offset from end of cfs_dir_header */
+	__le32 inode_num; /* Index in inode table */
+	__le32 name_offset; /* Offset from end of cfs_dir_header */
 	u8 name_len;
 	u8 d_type;
 	u16 _padding;
 };
 
-/* Directory entries, stored in variable data section, 32bit aligned, followed
- * by name string table */
+/* Directory entries, stored in variable data section, 32bit aligned,
+ * followed by name string table
+ */
 struct cfs_dir_header {
 	__le32 n_dirents;
 	struct cfs_dirent dirents[];
 };
 
-static inline size_t cfs_dir_header_size(size_t n_dirents) {
+static inline size_t cfs_dir_header_size(size_t n_dirents)
+{
 	return sizeof(struct cfs_dir_header) + n_dirents * sizeof(struct cfs_dirent);
 }
 
@@ -130,14 +137,17 @@ struct cfs_xattr_element {
 };
 
 /* Xattrs, stored in variable data section , 32bit aligned, followed
- * by key/value table */
+ * by key/value table
+ */
 struct cfs_xattr_header {
 	__le16 n_attr;
 	struct cfs_xattr_element attr[0];
 };
 
-static inline size_t cfs_xattr_header_size(size_t n_element) {
-	return sizeof(struct cfs_xattr_header) + n_element * sizeof(struct cfs_xattr_element);
+static inline size_t cfs_xattr_header_size(size_t n_element)
+{
+	return sizeof(struct cfs_xattr_header) +
+	       n_element * sizeof(struct cfs_xattr_element);
 }
 
 #endif

--- a/kernel/cfs.h
+++ b/kernel/cfs.h
@@ -73,17 +73,14 @@ struct cfs_vdata {
 	u32 len;
 } __packed;
 
-struct cfs_header_s {
-	u8 version;
-	u8 unused1;
-	u16 unused2;
+struct cfs_superblock {
+	__le32 version;
+	__le32 magic;
+	__le64 data_offset;
+	__le64 root_inode;
 
-	u32 magic;
-	u64 data_offset;
-	u64 root_inode;
-
-	u64 unused3[2];
-} __packed;
+	__le64 unused3[2];
+};
 
 enum cfs_inode_flags {
 	CFS_INODE_FLAGS_NONE = 0,

--- a/kernel/cfs.h
+++ b/kernel/cfs.h
@@ -21,11 +21,12 @@
 
 #define CFS_MAGIC 0xc078629aU
 
+#define CFS_ROOT_INO 0
+
 struct cfs_superblock {
 	__le32 version;
 	__le32 magic;
 	__le64 data_offset;
-	__le64 root_inode;
 
 	__le64 unused3[2];
 };
@@ -54,8 +55,7 @@ struct cfs_inode_data {
 };
 
 struct cfs_dirent {
-	/* Index of struct cfs_inode */
-	__le64 inode_index;
+	__le32 inode_num;
 	__le32 name_offset;  /* Offset from end of dir_header */
 	u8 name_len;
 	u8 d_type;

--- a/kernel/cfs.h
+++ b/kernel/cfs.h
@@ -17,51 +17,104 @@
 #include <linux/stat.h>
 #include <linux/types.h>
 
+/* Descriptor file layout:
+ *
+ *  +-----------------------+
+ *  | cfs_superblock        |
+ *  |   vdata_offfset       |---|
+ *  +-----------------------|   |
+ *  | Inode table           |   |
+ *  |  N * cfs_inode_data   |   |
+ *  +-----------------------|   |
+ *  | Variable data section |<--/
+ *  | Used for:             |
+ *  |  symlink targets      |
+ *  |  backing file paths   |
+ *  |  dirents              |
+ *  |  xattrs               |
+ *  |  digests              |
+ *  +-----------------------+
+ *
+ *  The superblock is at the start of the file, and the inode table
+ *  directly follows it. The variable data section found via
+ *  vdata_offset and all sections are 32bit aligned. All data is
+ *  little endian.
+ *
+ * The inode table is a table of fixed size cfs_inode_data elements.
+ * The filesystem inode numbers are 32bit indexes into this table.
+ * Actual file content (for regular files) is referenced by a backing
+ * file path which is looked up relative to a given base dir.
+ *
+ * All variable size data are stored in the variable data section and
+ * are referenced using cfs_vdata (64bit offset from the start of the
+ * vdata section and 32bit lengths).
+ *
+ * Directory dirent data is stored in one 32bit aligned vdata chunk,
+ * staring with a table of fixed size cfs_dirents and which is
+ * followed by a string table. The dirents reference the strings by
+ * offsets form the string table. The dirents are sorted for efficient
+ * binary search lookups.
+ *
+ * Xattrs data are stored in a 32bit aligned vdata chunk. This is
+ * a table of cfs_xattr, followed by the key/value data. The
+ * xattrs are sorted by key. Note that many inodes can reference
+ * the same xattr data.
+ */
+
+/* Current (and atm only) version of the image format. */
 #define CFS_VERSION 1
 
 #define CFS_MAGIC 0xc078629aU
 
+#define CFS_SUPERBLOCK_OFFSET 0
+#define CFS_INODE_TABLE_OFFSET sizeof(struct cfs_superblock)
 #define CFS_ROOT_INO 0
 
 struct cfs_superblock {
-	__le32 version;
-	__le32 magic;
-	__le64 data_offset;
+	__le32 version;      /* CFS_VERSION */
+	__le32 magic;        /* CFS_MAGIC */
+	__le64 vdata_offset; /* Offset of the variable data data
+				section from start of file */
 
-	__le64 unused3[2];
+	__le64 unused[2];    /* For future use */
 };
 
 struct cfs_vdata {
-	__le64 off;
+	__le64 off;  /* Offset into variable data section */
 	__le32 len;
 };
 
 struct cfs_inode_data {
-	__le32 st_mode; /* File type and mode.  */
-	__le32 st_nlink; /* Number of hard links, only for regular files.  */
-	__le32 st_uid; /* User ID of owner.  */
-	__le32 st_gid; /* Group ID of owner.  */
-	__le32 st_rdev; /* Device ID (if special file).  */
-	__le64 st_size; /* Size of file, only used for regular files */
+	__le32 st_mode;      /* File type and mode.  */
+	__le32 st_nlink;     /* Number of hard links, only for regular files.  */
+	__le32 st_uid;       /* User ID of owner.  */
+	__le32 st_gid;       /* Group ID of owner.  */
+	__le32 st_rdev;      /* Device ID (if special file).  */
+	__le64 st_size;      /* Size of file */
 	__le64 st_mtim_sec;
 	__le32 st_mtim_nsec;
 	__le64 st_ctim_sec;
 	__le32 st_ctim_nsec;
 
 	/* References to variable storage area: */
-	struct cfs_vdata variable_data; /* dirent, backing file or symlink target */
-	struct cfs_vdata xattrs; /* ref to variable data */
-	struct cfs_vdata digest;
+	struct cfs_vdata variable_data; /* per-type variable data:
+					   S_IFDIR: dirents
+					   S_IFREG: backing file pathnem
+					   S_IFLNLK; symlink target */
+	struct cfs_vdata xattrs;
+	struct cfs_vdata digest;  /* Expected fs-verity digest of backing file */
 };
 
 struct cfs_dirent {
-	__le32 inode_num;
-	__le32 name_offset;  /* Offset from end of dir_header */
+	__le32 inode_num;    /* Index in inode table */
+	__le32 name_offset;  /* Offset from end of cfs_dir_header */
 	u8 name_len;
 	u8 d_type;
 	u16 _padding;
 };
 
+/* Directory entries, stored in variable data section, 32bit aligned, followed
+ * by name string table */
 struct cfs_dir_header {
 	__le32 n_dirents;
 	struct cfs_dirent dirents[];
@@ -71,12 +124,13 @@ static inline size_t cfs_dir_header_size(size_t n_dirents) {
 	return sizeof(struct cfs_dir_header) + n_dirents * sizeof(struct cfs_dirent);
 }
 
-/* xattr representation.  */
 struct cfs_xattr_element {
 	__le16 key_length;
 	__le16 value_length;
 };
 
+/* Xattrs, stored in variable data section , 32bit aligned, followed
+ * by key/value table */
 struct cfs_xattr_header {
 	__le16 n_attr;
 	struct cfs_xattr_element attr[0];

--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -805,8 +805,8 @@ static int write_inodes(struct lcfs_ctx_s *ctx)
 int lcfs_write_to(struct lcfs_node_s *root, void *file, lcfs_write_cb write_cb,
 		  uint8_t *digest_out)
 {
-	struct lcfs_header_s header = {
-		.version = LCFS_VERSION,
+	struct lcfs_superblock_s superblock = {
+		.version = lcfs_u32_to_file(LCFS_VERSION),
 		.magic = lcfs_u32_to_file(LCFS_MAGIC),
 	};
 	int ret = 0;
@@ -836,10 +836,10 @@ int lcfs_write_to(struct lcfs_node_s *root, void *file, lcfs_write_cb write_cb,
 		return ret;
 	}
 
-	data_offset = ALIGN_TO(sizeof(struct lcfs_header_s) + ctx->inode_table_size, 4);
+	data_offset = ALIGN_TO(sizeof(struct lcfs_superblock_s) + ctx->inode_table_size, 4);
 
-	header.data_offset = lcfs_u64_to_file(data_offset);
-	header.root_inode = lcfs_u64_to_file(root->inode_index);
+	superblock.data_offset = lcfs_u64_to_file(data_offset);
+	superblock.root_inode = lcfs_u64_to_file(root->inode_index);
 
 	ret = compute_dirents(ctx);
 	if (ret < 0) {
@@ -853,7 +853,7 @@ int lcfs_write_to(struct lcfs_node_s *root, void *file, lcfs_write_cb write_cb,
 		return ret;
 	}
 
-	ret = lcfs_write(ctx, &header, sizeof(header));
+	ret = lcfs_write(ctx, &superblock, sizeof(superblock));
 	if (ret < 0) {
 		lcfs_close(ctx);
 		return ret;
@@ -866,7 +866,7 @@ int lcfs_write_to(struct lcfs_node_s *root, void *file, lcfs_write_cb write_cb,
 	}
 
 	assert(ctx->bytes_written ==
-	       sizeof(struct lcfs_header_s) + ctx->inode_table_size);
+	       sizeof(struct lcfs_superblock_s) + ctx->inode_table_size);
 
 	if (ctx->vdata) {
 		/* Pad vdata to 4k alignment */

--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -467,7 +467,7 @@ static int compute_dirents(struct lcfs_ctx_s *ctx, struct lcfs_node_s *node, str
 		name_offset += dirent->name_len;
 	}
 
-	r = lcfs_append_vdata(ctx, vdata, buffer, dirents_size);
+	r = lcfs_append_vdata_no_dedup(ctx, vdata, buffer, dirents_size);
 	free(buffer);
 	return r;
 }

--- a/libcomposefs/lcfs.h
+++ b/libcomposefs/lcfs.h
@@ -82,9 +82,9 @@ struct lcfs_inode_s {
 	uint32_t st_gid; /* Group ID of owner.  */
 	uint32_t st_rdev; /* Device ID (if special file).  */
 	uint64_t st_size; /* Size of file, only used for regular files */
-	int64_t  st_mtim_sec;
+	int64_t st_mtim_sec;
 	uint32_t st_mtim_nsec;
-	int64_t  st_ctim_sec;
+	int64_t st_ctim_sec;
 	uint32_t st_ctim_nsec;
 
 	/* References to variable storage area: */
@@ -106,8 +106,10 @@ struct lcfs_dir_header_s {
 	struct lcfs_dirent_s dirents[0];
 };
 
-static inline size_t lcfs_dir_header_size(size_t n_dirents) {
-	return sizeof(struct lcfs_dir_header_s) + n_dirents * sizeof(struct lcfs_dirent_s);
+static inline size_t lcfs_dir_header_size(size_t n_dirents)
+{
+	return sizeof(struct lcfs_dir_header_s) +
+	       n_dirents * sizeof(struct lcfs_dirent_s);
 }
 
 /* xattr representation.  */
@@ -121,8 +123,10 @@ struct lcfs_xattr_header_s {
 	struct lcfs_xattr_element_s attr[0];
 };
 
-static inline size_t lcfs_xattr_header_size(size_t n_element) {
-	return sizeof(struct lcfs_xattr_header_s) + n_element * sizeof(struct lcfs_xattr_element_s);
+static inline size_t lcfs_xattr_header_size(size_t n_element)
+{
+	return sizeof(struct lcfs_xattr_header_s) +
+	       n_element * sizeof(struct lcfs_xattr_element_s);
 }
 
 #endif

--- a/libcomposefs/lcfs.h
+++ b/libcomposefs/lcfs.h
@@ -65,7 +65,7 @@ static inline uint64_t lcfs_u64_from_file(uint64_t val)
 struct lcfs_superblock_s {
 	uint32_t version;
 	uint32_t magic;
-	uint64_t data_offset;
+	uint64_t vdata_offset;
 
 	uint64_t unused3[2];
 };

--- a/libcomposefs/lcfs.h
+++ b/libcomposefs/lcfs.h
@@ -127,17 +127,14 @@ struct lcfs_vdata_s {
 	uint32_t len;
 } __attribute__((packed));
 
-struct lcfs_header_s {
-	uint8_t version;
-	uint8_t unused1;
-	uint16_t unused2;
-
+struct lcfs_superblock_s {
+	uint32_t version;
 	uint32_t magic;
 	uint64_t data_offset;
 	uint64_t root_inode;
 
 	uint64_t unused3[2];
-} __attribute__((packed));
+};
 
 enum lcfs_inode_flags {
 	LCFS_INODE_FLAGS_NONE = 0,

--- a/libcomposefs/lcfs.h
+++ b/libcomposefs/lcfs.h
@@ -66,7 +66,6 @@ struct lcfs_superblock_s {
 	uint32_t version;
 	uint32_t magic;
 	uint64_t data_offset;
-	uint64_t root_inode;
 
 	uint64_t unused3[2];
 };
@@ -95,8 +94,7 @@ struct lcfs_inode_s {
 };
 
 struct lcfs_dirent_s {
-	/* Index of struct lcfs_inode_s */
-	uint64_t inode_index;
+	uint32_t inode_num;
 	uint32_t name_offset; /* Offset from end of dir_header */
 	uint8_t name_len;
 	uint8_t d_type;

--- a/tools/dump.c
+++ b/tools/dump.c
@@ -306,12 +306,11 @@ int main(int argc, char *argv[])
 
 	superblock = (struct lcfs_superblock_s *)data;
 
-	if (lcfs_u64_from_file(superblock->data_offset) > size)
+	data_offset = lcfs_u64_from_file(superblock->vdata_offset);
+	if (data_offset > size || data_offset % 4 != 0)
 		error(EXIT_FAILURE, EINVAL, "Invalid data offset");
 
 	inode_data = data + sizeof(struct lcfs_superblock_s);
-	data_offset = lcfs_u64_from_file(superblock->data_offset);
-	assert(data_offset % 4 == 0);
 	vdata = data + data_offset;
 	if (mode == DUMP) {
 		dump_inode(inode_data, vdata, "", 0, 0, 0, false,

--- a/tools/dump.c
+++ b/tools/dump.c
@@ -51,7 +51,8 @@ static int get_file_size(int fd, off_t *out)
 	return 0;
 }
 
-static const void *get_v_data(struct lcfs_inode_s *ino, const uint8_t *vdata, void *default_val)
+static const void *get_v_data(struct lcfs_inode_s *ino, const uint8_t *vdata,
+			      void *default_val)
 {
 	if (ino->variable_data.len == 0)
 		return default_val;
@@ -62,7 +63,9 @@ static const void *get_v_data(struct lcfs_inode_s *ino, const uint8_t *vdata, vo
 static void decode_inode(const uint8_t *inode_data, uint32_t inod_num,
 			 struct lcfs_inode_s *ino)
 {
-	const struct lcfs_inode_s *data = (const struct lcfs_inode_s *)(inode_data + inod_num * sizeof(struct lcfs_inode_s));
+	const struct lcfs_inode_s *data =
+		(const struct lcfs_inode_s *)(inode_data +
+					      inod_num * sizeof(struct lcfs_inode_s));
 
 	*ino = *data;
 
@@ -77,11 +80,11 @@ static void decode_inode(const uint8_t *inode_data, uint32_t inod_num,
 	ino->st_ctim_sec = lcfs_u64_from_file(ino->st_ctim_sec);
 	ino->st_ctim_nsec = lcfs_u32_from_file(ino->st_ctim_nsec);
 
-        ino->variable_data.off = lcfs_u64_from_file(ino->variable_data.off);
-        ino->variable_data.len = lcfs_u32_from_file(ino->variable_data.len);
+	ino->variable_data.off = lcfs_u64_from_file(ino->variable_data.off);
+	ino->variable_data.len = lcfs_u32_from_file(ino->variable_data.len);
 
-        ino->xattrs.off = lcfs_u64_from_file(ino->xattrs.off);
-        ino->xattrs.len = lcfs_u32_from_file(ino->xattrs.len);
+	ino->xattrs.off = lcfs_u64_from_file(ino->xattrs.off);
+	ino->xattrs.len = lcfs_u32_from_file(ino->xattrs.len);
 }
 
 static void digest_to_string(const uint8_t *csum, char *buf)
@@ -174,15 +177,20 @@ static int dump_inode(const uint8_t *inode_data, const uint8_t *vdata,
 	}
 
 	if (dirp && recurse && ino.variable_data.len != 0) {
-		const struct lcfs_dir_header_s *dir = (const struct lcfs_dir_header_s *)(vdata + ino.variable_data.off);
+		const struct lcfs_dir_header_s *dir =
+			(const struct lcfs_dir_header_s *)(vdata +
+							   ino.variable_data.off);
 		uint32_t n_dirents = lcfs_u32_from_file(dir->n_dirents);
-		const char *namedata = (const char *)dir + lcfs_dir_header_size(n_dirents);
+		const char *namedata =
+			(const char *)dir + lcfs_dir_header_size(n_dirents);
 
 		for (i = 0; i < n_dirents; i++) {
 			size_t child_name_len = dir->dirents[i].name_len;
-			size_t child_name_offset = lcfs_u32_from_file(dir->dirents[i].name_offset);
+			size_t child_name_offset =
+				lcfs_u32_from_file(dir->dirents[i].name_offset);
 
-			dump_inode(inode_data, vdata, namedata + child_name_offset, child_name_len,
+			dump_inode(inode_data, vdata,
+				   namedata + child_name_offset, child_name_len,
 				   lcfs_u32_from_file(dir->dirents[i].inode_num),
 				   rec + 1, extended, xattrs, recurse);
 		}
@@ -192,7 +200,7 @@ static int dump_inode(const uint8_t *inode_data, const uint8_t *vdata,
 }
 
 static uint64_t find_child(const uint8_t *inode_data, const uint8_t *vdata,
-                           uint32_t current, const char *name)
+			   uint32_t current, const char *name)
 {
 	struct lcfs_inode_s ino;
 	const struct lcfs_dir_header_s *dir;
@@ -215,7 +223,8 @@ static uint64_t find_child(const uint8_t *inode_data, const uint8_t *vdata,
 	name_len = strlen(name);
 	for (i = 0; i < n_dirents; i++) {
 		size_t child_name_len = dir->dirents[i].name_len;
-		size_t child_name_offset = lcfs_u32_from_file(dir->dirents[i].name_offset);
+		size_t child_name_offset =
+			lcfs_u32_from_file(dir->dirents[i].name_offset);
 		if (name_len == child_name_len &&
 		    memcmp(name, namedata + child_name_offset, name_len) == 0) {
 			return lcfs_u64_from_file(dir->dirents[i].inode_num);
@@ -226,7 +235,7 @@ static uint64_t find_child(const uint8_t *inode_data, const uint8_t *vdata,
 }
 
 static uint64_t lookup(const uint8_t *inode_data, const uint8_t *vdata,
-                       uint64_t parent, const void *what)
+		       uint64_t parent, const void *what)
 {
 	char *it;
 	char *dpath, *path;
@@ -313,8 +322,7 @@ int main(int argc, char *argv[])
 	inode_data = data + sizeof(struct lcfs_superblock_s);
 	vdata = data + data_offset;
 	if (mode == DUMP) {
-		dump_inode(inode_data, vdata, "", 0, 0, 0, false,
-			   false, true);
+		dump_inode(inode_data, vdata, "", 0, 0, 0, false, false, true);
 	} else if (mode == DUMP_EXTENDED) {
 		dump_inode(inode_data, vdata, "", 0, 0, 0, true, false, true);
 	} else if (mode == LOOKUP) {

--- a/tools/dump.c
+++ b/tools/dump.c
@@ -357,7 +357,7 @@ int main(int argc, char *argv[])
 	const uint8_t *inode_data;
 	uint8_t *vdata;
 	size_t root_index;
-	struct lcfs_header_s *header;
+	struct lcfs_superblock_s *superblock;
 	size_t data_offset;
 
 	if (argc < 3)
@@ -391,16 +391,16 @@ int main(int argc, char *argv[])
 	if (data == MAP_FAILED)
 		error(EXIT_FAILURE, errno, "fstat %s", argv[1]);
 
-	header = (struct lcfs_header_s *)data;
+	superblock = (struct lcfs_superblock_s *)data;
 
-	if (lcfs_u64_from_file(header->data_offset) > size)
+	if (lcfs_u64_from_file(superblock->data_offset) > size)
 		error(EXIT_FAILURE, EINVAL, "Invalid data offset");
 
-	inode_data = data + sizeof(struct lcfs_header_s);
-	data_offset = lcfs_u64_from_file(header->data_offset);
+	inode_data = data + sizeof(struct lcfs_superblock_s);
+	data_offset = lcfs_u64_from_file(superblock->data_offset);
 	assert(data_offset % 4 == 0);
 	vdata = data + data_offset;
-	root_index = lcfs_u64_from_file(header->root_inode);
+	root_index = lcfs_u64_from_file(superblock->root_inode);
 	if (mode == DUMP) {
 		dump_inode(inode_data, vdata, "", 0, root_index, 0, false,
 			   false, true);


### PR DESCRIPTION
This follows the discussion with dave chinner on the list. The descriptors are slightly larger (around 40%) but the format, as well as the code is much simpler and more performance.

We also drop the chunking of dirents in favour of using multi-page mappings (using vm_map_ram()) when reading the data from the page cache.,

This also adds various comments describing the file format in the header and generally fixes issues pointed out in the reviews.