### PR TITLE
Correctly handle sizes

### DIFF
--- a/kernel/cfs.c
+++ b/kernel/cfs.c
@@ -131,7 +131,6 @@ static struct inode *cfs_make_inode(struct cfs_context *ctx, struct super_block 
 	case S_IFDIR:
 		inode->i_op = &cfs_dir_inode_operations;
 		inode->i_fop = &cfs_dir_operations;
-		inode->i_size = 4096;
 		break;
 	case S_IFCHR:
 	case S_IFBLK:
@@ -697,9 +696,6 @@ static const struct xattr_handler *cfs_xattr_handlers[] = {
 };
 
 static const struct inode_operations cfs_file_inode_operations = {
-	.setattr = simple_setattr,
-	.getattr = simple_getattr,
-
 	.listxattr = cfs_listxattr,
 };
 

--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -892,10 +892,9 @@ struct lcfs_node_s *lcfs_load_node_from_file(int dirfd, const char *fname,
 	ret->inode.st_uid = sb.st_uid;
 	ret->inode.st_gid = sb.st_gid;
 	ret->inode.st_rdev = sb.st_rdev;
+	ret->inode.st_size = sb.st_size;
 
 	if ((sb.st_mode & S_IFMT) == S_IFREG) {
-		ret->inode.st_size = sb.st_size;
-
 		if (sb.st_size != 0 && (buildflags & LCFS_BUILD_COMPUTE_DIGEST) != 0) {
 			int fd = openat(dirfd, fname, O_RDONLY | O_CLOEXEC);
 			if (fd < 0) {


### PR DESCRIPTION
Use i_size_write to set i_size, and also call inode_set_bytes() to set i_blocks and i_bytes.

Drop the use of simple_get/setattr. These are just confusing as they overwrite i_blocks. The default generic_fillattrs work fine for us.

Also, don't randomly hardcode st_size for dirs, just follow whatever the inode data says, for simplicity.

Signed-off-by: Alexander Larsson <alexl@redhat.com>