### PR TITLE
Fix on-disk struct sizes

### DIFF
--- a/kernel/cfs.h
+++ b/kernel/cfs.h
@@ -77,13 +77,16 @@ struct cfs_superblock {
 	/* Offset of the variable data section from start of file */
 	__le64 vdata_offset;
 
-	__le64 unused[2]; /* For future use */
-};
+	/* For future use, and makes superblock 128 bytes to align
+	 * inode table on cacheline boundary on most arches.
+	 */
+	__le32 unused[28];
+} __packed;
 
 struct cfs_vdata {
 	__le64 off; /* Offset into variable data section */
 	__le32 len;
-};
+} __packed;
 
 struct cfs_inode_data {
 	__le32 st_mode; /* File type and mode.  */
@@ -108,7 +111,12 @@ struct cfs_inode_data {
 
 	struct cfs_vdata xattrs;
 	struct cfs_vdata digest; /* Expected fs-verity digest of backing file */
-};
+
+	/* For future use, and makes inode_data 96 bytes which
+	 * is semi-aligned with cacheline sizes.
+	 */
+	__le32 unused[2];
+} __packed;
 
 struct cfs_dirent {
 	__le32 inode_num; /* Index in inode table */
@@ -116,7 +124,7 @@ struct cfs_dirent {
 	u8 name_len;
 	u8 d_type;
 	u16 _padding;
-};
+} __packed;
 
 /* Directory entries, stored in variable data section, 32bit aligned,
  * followed by name string table
@@ -124,7 +132,7 @@ struct cfs_dirent {
 struct cfs_dir_header {
 	__le32 n_dirents;
 	struct cfs_dirent dirents[];
-};
+} __packed;
 
 static inline size_t cfs_dir_header_size(size_t n_dirents)
 {
@@ -134,7 +142,7 @@ static inline size_t cfs_dir_header_size(size_t n_dirents)
 struct cfs_xattr_element {
 	__le16 key_length;
 	__le16 value_length;
-};
+} __packed;
 
 /* Xattrs, stored in variable data section , 32bit aligned, followed
  * by key/value table
@@ -142,7 +150,7 @@ struct cfs_xattr_element {
 struct cfs_xattr_header {
 	__le16 n_attr;
 	struct cfs_xattr_element attr[0];
-};
+} __packed;
 
 static inline size_t cfs_xattr_header_size(size_t n_element)
 {

--- a/libcomposefs/lcfs.h
+++ b/libcomposefs/lcfs.h
@@ -67,13 +67,15 @@ struct lcfs_superblock_s {
 	uint32_t magic;
 	uint64_t vdata_offset;
 
-	uint64_t unused3[2];
-};
+	/* For future use, and makes superblock 128 bytes to align
+	 * inode table on cacheline boundary on most arches. */
+	uint32_t unused[28];
+} __attribute__((__packed__));
 
 struct lcfs_vdata_s {
 	uint64_t off;
 	uint32_t len;
-};
+} __attribute__((__packed__));
 
 struct lcfs_inode_s {
 	uint32_t st_mode; /* File type and mode.  */
@@ -91,7 +93,12 @@ struct lcfs_inode_s {
 	struct lcfs_vdata_s variable_data; /* dirent, backing file or symlink target */
 	struct lcfs_vdata_s xattrs;
 	struct lcfs_vdata_s digest;
-};
+
+	/* For future use, and makes inode_data 96 bytes which
+	 * is semi-aligned with cacheline sizes. */
+	uint32_t unused[2];
+} __attribute__((__packed__));
+;
 
 struct lcfs_dirent_s {
 	uint32_t inode_num;
@@ -99,12 +106,14 @@ struct lcfs_dirent_s {
 	uint8_t name_len;
 	uint8_t d_type;
 	uint16_t _padding;
-};
+} __attribute__((__packed__));
+;
 
 struct lcfs_dir_header_s {
 	uint32_t n_dirents;
 	struct lcfs_dirent_s dirents[0];
-};
+} __attribute__((__packed__));
+;
 
 static inline size_t lcfs_dir_header_size(size_t n_dirents)
 {
@@ -116,12 +125,14 @@ static inline size_t lcfs_dir_header_size(size_t n_dirents)
 struct lcfs_xattr_element_s {
 	uint16_t key_length;
 	uint16_t value_length;
-};
+} __attribute__((__packed__));
+;
 
 struct lcfs_xattr_header_s {
 	uint16_t n_attr;
 	struct lcfs_xattr_element_s attr[0];
-};
+} __attribute__((__packed__));
+;
 
 static inline size_t lcfs_xattr_header_size(size_t n_element)
 {


### PR DESCRIPTION
This puts back the packed attributes on the on-disk struct, because otherwise we get a lot of holes in them, making things larger. We also add some "unused" padding to make the various structures fully or partially cacheline aligned.

Signed-off-by: Alexander Larsson <alexl@redhat.com>