### PR TITLE
kernel: Drop root_inode from cfs_context

### DIFF
--- a/kernel/cfs-internals.h
+++ b/kernel/cfs-internals.h
@@ -25,7 +25,6 @@ struct cfs_inode_extra_data {
 struct cfs_context {
 	struct file *descriptor;
 	u64 vdata_offset;
-	u64 root_inode;
 
 	u64 descriptor_len;
 };


### PR DESCRIPTION
This is not used anymore

Signed-off-by: Alexander Larsson <alexl@redhat.com>