### PR TITLE
kernel: Fix binary search bounds check

### DIFF
--- a/kernel/cfs-reader.c
+++ b/kernel/cfs-reader.c
@@ -706,8 +706,10 @@ int cfs_dir_lookup(struct cfs_context *ctx, u64 index,
 
 		if (cmp > 0)
 			start_dirent = mid_dirent + 1;
-		else
+		else if (mid_dirent > 0)
 			end_dirent = mid_dirent - 1;
+		else
+			break;
 	}
 
 	/* not found */


### PR DESCRIPTION
The binary search was handling the case of looking up something before the table, because when the lookup at start=0 end=0 (mid=0) fails, end was set to mid - 1, which is negative, so still passes the loop check for start_dirent <= end_dirent.

Signed-off-by: Alexander Larsson <alexl@redhat.com>