### PR TITLE
Initial work on erofs support in mkcomposefs

### DIFF
--- a/hacking/clang-format/Makefile
+++ b/hacking/clang-format/Makefile
@@ -2,6 +2,6 @@ all:
 
 clang-format:
 	# do not format files that were copied into the source directory.
-	git ls-files ../../libcomposefs ../../tools ../../kernel | egrep "\\.[hc]" | grep -v "bitrotate\|hash\|xalloc-oversized" | xargs clang-format -style=file -i
+	git ls-files ../../libcomposefs ../../tools ../../kernel | egrep "\\.[hc]" | grep -v "bitrotate\|hash\|xalloc-oversized\|erofs_fs" | xargs clang-format -style=file -i
 
 .PHONY: clang-format

--- a/kernel/cfs.c
+++ b/kernel/cfs.c
@@ -448,13 +448,13 @@ static int cfs_fill_super(struct super_block *sb, struct fs_context *fc)
 		lower = splitlower;
 		for (size_t i = 0; i < numbasedirs; i++) {
 			mnt = resolve_basedir(lower);
-			stack_depth = max(stack_depth, mnt->mnt_sb->s_stack_depth);
 			if (IS_ERR(mnt)) {
 				ret = PTR_ERR(mnt);
 				kfree(splitlower);
 				goto fail;
 			}
 			bases[i] = mnt;
+			stack_depth = max(stack_depth, mnt->mnt_sb->s_stack_depth);
 
 			lower = strchr(lower, '\0') + 1;
 		}

--- a/libcomposefs/erofs_fs.h
+++ b/libcomposefs/erofs_fs.h
@@ -1,0 +1,452 @@
+/* SPDX-License-Identifier: GPL-2.0-only OR Apache-2.0 */
+/*
+ * EROFS (Enhanced ROM File System) on-disk format definition
+ *
+ * Copyright (C) 2017-2018 HUAWEI, Inc.
+ *             https://www.huawei.com/
+ * Copyright (C) 2021, Alibaba Cloud
+ */
+#ifndef __EROFS_FS_H
+#define __EROFS_FS_H
+
+#define EROFS_SUPER_OFFSET      1024
+
+#define EROFS_FEATURE_COMPAT_SB_CHKSUM          0x00000001
+#define EROFS_FEATURE_COMPAT_MTIME              0x00000002
+
+/*
+ * Any bits that aren't in EROFS_ALL_FEATURE_INCOMPAT should
+ * be incompatible with this kernel version.
+ */
+#define EROFS_FEATURE_INCOMPAT_ZERO_PADDING	0x00000001
+#define EROFS_FEATURE_INCOMPAT_COMPR_CFGS	0x00000002
+#define EROFS_FEATURE_INCOMPAT_BIG_PCLUSTER	0x00000002
+#define EROFS_FEATURE_INCOMPAT_CHUNKED_FILE	0x00000004
+#define EROFS_FEATURE_INCOMPAT_DEVICE_TABLE	0x00000008
+#define EROFS_FEATURE_INCOMPAT_COMPR_HEAD2	0x00000008
+#define EROFS_FEATURE_INCOMPAT_ZTAILPACKING	0x00000010
+#define EROFS_FEATURE_INCOMPAT_FRAGMENTS	0x00000020
+#define EROFS_FEATURE_INCOMPAT_DEDUPE		0x00000020
+#define EROFS_ALL_FEATURE_INCOMPAT		\
+	(EROFS_FEATURE_INCOMPAT_ZERO_PADDING | \
+	 EROFS_FEATURE_INCOMPAT_COMPR_CFGS | \
+	 EROFS_FEATURE_INCOMPAT_BIG_PCLUSTER | \
+	 EROFS_FEATURE_INCOMPAT_CHUNKED_FILE | \
+	 EROFS_FEATURE_INCOMPAT_DEVICE_TABLE | \
+	 EROFS_FEATURE_INCOMPAT_COMPR_HEAD2 | \
+	 EROFS_FEATURE_INCOMPAT_ZTAILPACKING | \
+	 EROFS_FEATURE_INCOMPAT_FRAGMENTS | \
+	 EROFS_FEATURE_INCOMPAT_DEDUPE)
+
+#define EROFS_SB_EXTSLOT_SIZE	16
+
+struct erofs_deviceslot {
+	u8 tag[64];		/* digest(sha256), etc. */
+	__le32 blocks;		/* total fs blocks of this device */
+	__le32 mapped_blkaddr;	/* map starting at mapped_blkaddr */
+	u8 reserved[56];
+};
+#define EROFS_DEVT_SLOT_SIZE	sizeof(struct erofs_deviceslot)
+
+/* erofs on-disk super block (currently 128 bytes) */
+struct erofs_super_block {
+	__le32 magic;           /* file system magic number */
+	__le32 checksum;        /* crc32c(super_block) */
+	__le32 feature_compat;
+	__u8 blkszbits;         /* support block_size == PAGE_SIZE only */
+	__u8 sb_extslots;	/* superblock size = 128 + sb_extslots * 16 */
+
+	__le16 root_nid;	/* nid of root directory */
+	__le64 inos;            /* total valid ino # (== f_files - f_favail) */
+
+	__le64 build_time;      /* compact inode time derivation */
+	__le32 build_time_nsec;	/* compact inode time derivation in ns scale */
+	__le32 blocks;          /* used for statfs */
+	__le32 meta_blkaddr;	/* start block address of metadata area */
+	__le32 xattr_blkaddr;	/* start block address of shared xattr area */
+	__u8 uuid[16];          /* 128-bit uuid for volume */
+	__u8 volume_name[16];   /* volume name */
+	__le32 feature_incompat;
+	union {
+		/* bitmap for available compression algorithms */
+		__le16 available_compr_algs;
+		/* customized sliding window size instead of 64k by default */
+		__le16 lz4_max_distance;
+	} __packed u1;
+	__le16 extra_devices;	/* # of devices besides the primary device */
+	__le16 devt_slotoff;	/* startoff = devt_slotoff * devt_slotsize */
+	__u8 reserved[6];
+	__le64 packed_nid;	/* nid of the special packed inode */
+	__u8 reserved2[24];
+};
+
+/*
+ * erofs inode datalayout (i_format in on-disk inode):
+ * 0 - uncompressed flat inode without tail-packing inline data:
+ * inode, [xattrs], ... | ... | no-holed data
+ * 1 - compressed inode with non-compact indexes:
+ * inode, [xattrs], [map_header], extents ... | ...
+ * 2 - uncompressed flat inode with tail-packing inline data:
+ * inode, [xattrs], tailpacking data, ... | ... | no-holed data
+ * 3 - compressed inode with compact indexes:
+ * inode, [xattrs], map_header, extents ... | ...
+ * 4 - chunk-based inode with (optional) multi-device support:
+ * inode, [xattrs], chunk indexes ... | ...
+ * 5~7 - reserved
+ */
+enum {
+	EROFS_INODE_FLAT_PLAIN			= 0,
+	EROFS_INODE_FLAT_COMPRESSION_LEGACY	= 1,
+	EROFS_INODE_FLAT_INLINE			= 2,
+	EROFS_INODE_FLAT_COMPRESSION		= 3,
+	EROFS_INODE_CHUNK_BASED			= 4,
+	EROFS_INODE_DATALAYOUT_MAX
+};
+
+static inline bool erofs_inode_is_data_compressed(unsigned int datamode)
+{
+	return datamode == EROFS_INODE_FLAT_COMPRESSION ||
+		datamode == EROFS_INODE_FLAT_COMPRESSION_LEGACY;
+}
+
+/* bit definitions of inode i_format */
+#define EROFS_I_VERSION_BITS            1
+#define EROFS_I_DATALAYOUT_BITS         3
+
+#define EROFS_I_VERSION_BIT             0
+#define EROFS_I_DATALAYOUT_BIT          1
+
+#define EROFS_I_ALL	\
+	((1 << (EROFS_I_DATALAYOUT_BIT + EROFS_I_DATALAYOUT_BITS)) - 1)
+
+/* indicate chunk blkbits, thus 'chunksize = blocksize << chunk blkbits' */
+#define EROFS_CHUNK_FORMAT_BLKBITS_MASK		0x001F
+/* with chunk indexes or just a 4-byte blkaddr array */
+#define EROFS_CHUNK_FORMAT_INDEXES		0x0020
+
+#define EROFS_CHUNK_FORMAT_ALL	\
+	(EROFS_CHUNK_FORMAT_BLKBITS_MASK | EROFS_CHUNK_FORMAT_INDEXES)
+
+struct erofs_inode_chunk_info {
+	__le16 format;		/* chunk blkbits, etc. */
+	__le16 reserved;
+};
+
+/* 32-byte reduced form of an ondisk inode */
+struct erofs_inode_compact {
+	__le16 i_format;	/* inode format hints */
+
+/* 1 header + n-1 * 4 bytes inline xattr to keep continuity */
+	__le16 i_xattr_icount;
+	__le16 i_mode;
+	__le16 i_nlink;
+	__le32 i_size;
+	__le32 i_reserved;
+	union {
+		/* total compressed blocks for compressed inodes */
+		__le32 compressed_blocks;
+		/* block address for uncompressed flat inodes */
+		__le32 raw_blkaddr;
+
+		/* for device files, used to indicate old/new device # */
+		__le32 rdev;
+
+		/* for chunk-based files, it contains the summary info */
+		struct erofs_inode_chunk_info c;
+	} i_u;
+	__le32 i_ino;           /* only used for 32-bit stat compatibility */
+	__le16 i_uid;
+	__le16 i_gid;
+	__le32 i_reserved2;
+};
+
+/* 32-byte on-disk inode */
+#define EROFS_INODE_LAYOUT_COMPACT	0
+/* 64-byte on-disk inode */
+#define EROFS_INODE_LAYOUT_EXTENDED	1
+
+/* 64-byte complete form of an ondisk inode */
+struct erofs_inode_extended {
+	__le16 i_format;	/* inode format hints */
+
+/* 1 header + n-1 * 4 bytes inline xattr to keep continuity */
+	__le16 i_xattr_icount;
+	__le16 i_mode;
+	__le16 i_reserved;
+	__le64 i_size;
+	union {
+		/* total compressed blocks for compressed inodes */
+		__le32 compressed_blocks;
+		/* block address for uncompressed flat inodes */
+		__le32 raw_blkaddr;
+
+		/* for device files, used to indicate old/new device # */
+		__le32 rdev;
+
+		/* for chunk-based files, it contains the summary info */
+		struct erofs_inode_chunk_info c;
+	} i_u;
+
+	/* only used for 32-bit stat compatibility */
+	__le32 i_ino;
+
+	__le32 i_uid;
+	__le32 i_gid;
+	__le64 i_mtime;
+	__le32 i_mtime_nsec;
+	__le32 i_nlink;
+	__u8   i_reserved2[16];
+};
+
+#define EROFS_MAX_SHARED_XATTRS         (128)
+/* h_shared_count between 129 ... 255 are special # */
+#define EROFS_SHARED_XATTR_EXTENT       (255)
+
+/*
+ * inline xattrs (n == i_xattr_icount):
+ * erofs_xattr_ibody_header(1) + (n - 1) * 4 bytes
+ *          12 bytes           /                   \
+ *                            /                     \
+ *                           /-----------------------\
+ *                           |  erofs_xattr_entries+ |
+ *                           +-----------------------+
+ * inline xattrs must starts in erofs_xattr_ibody_header,
+ * for read-only fs, no need to introduce h_refcount
+ */
+struct erofs_xattr_ibody_header {
+	__le32 h_reserved;
+	__u8   h_shared_count;
+	__u8   h_reserved2[7];
+	__le32 h_shared_xattrs[];       /* shared xattr id array */
+};
+
+/* Name indexes */
+#define EROFS_XATTR_INDEX_USER              1
+#define EROFS_XATTR_INDEX_POSIX_ACL_ACCESS  2
+#define EROFS_XATTR_INDEX_POSIX_ACL_DEFAULT 3
+#define EROFS_XATTR_INDEX_TRUSTED           4
+#define EROFS_XATTR_INDEX_LUSTRE            5
+#define EROFS_XATTR_INDEX_SECURITY          6
+
+/* xattr entry (for both inline & shared xattrs) */
+struct erofs_xattr_entry {
+	__u8   e_name_len;      /* length of name */
+	__u8   e_name_index;    /* attribute name index */
+	__le16 e_value_size;    /* size of attribute value */
+	/* followed by e_name and e_value */
+	char   e_name[];        /* attribute name */
+};
+
+static inline unsigned int erofs_xattr_ibody_size(__le16 i_xattr_icount)
+{
+	if (!i_xattr_icount)
+		return 0;
+
+	return sizeof(struct erofs_xattr_ibody_header) +
+		sizeof(__u32) * (le16_to_cpu(i_xattr_icount) - 1);
+}
+
+#define EROFS_XATTR_ALIGN(size) round_up(size, sizeof(struct erofs_xattr_entry))
+
+static inline unsigned int erofs_xattr_entry_size(struct erofs_xattr_entry *e)
+{
+	return EROFS_XATTR_ALIGN(sizeof(struct erofs_xattr_entry) +
+				 e->e_name_len + le16_to_cpu(e->e_value_size));
+}
+
+/* represent a zeroed chunk (hole) */
+#define EROFS_NULL_ADDR			-1
+
+/* 4-byte block address array */
+#define EROFS_BLOCK_MAP_ENTRY_SIZE	sizeof(__le32)
+
+/* 8-byte inode chunk indexes */
+struct erofs_inode_chunk_index {
+	__le16 advise;		/* always 0, don't care for now */
+	__le16 device_id;	/* back-end storage id (with bits masked) */
+	__le32 blkaddr;		/* start block address of this inode chunk */
+};
+
+/* maximum supported size of a physical compression cluster */
+#define Z_EROFS_PCLUSTER_MAX_SIZE	(1024 * 1024)
+
+/* available compression algorithm types (for h_algorithmtype) */
+enum {
+	Z_EROFS_COMPRESSION_LZ4		= 0,
+	Z_EROFS_COMPRESSION_LZMA	= 1,
+	Z_EROFS_COMPRESSION_MAX
+};
+#define Z_EROFS_ALL_COMPR_ALGS		((1 << Z_EROFS_COMPRESSION_MAX) - 1)
+
+/* 14 bytes (+ length field = 16 bytes) */
+struct z_erofs_lz4_cfgs {
+	__le16 max_distance;
+	__le16 max_pclusterblks;
+	u8 reserved[10];
+} __packed;
+
+/* 14 bytes (+ length field = 16 bytes) */
+struct z_erofs_lzma_cfgs {
+	__le32 dict_size;
+	__le16 format;
+	u8 reserved[8];
+} __packed;
+
+#define Z_EROFS_LZMA_MAX_DICT_SIZE	(8 * Z_EROFS_PCLUSTER_MAX_SIZE)
+
+/*
+ * bit 0 : COMPACTED_2B indexes (0 - off; 1 - on)
+ *  e.g. for 4k logical cluster size,      4B        if compacted 2B is off;
+ *                                  (4B) + 2B + (4B) if compacted 2B is on.
+ * bit 1 : HEAD1 big pcluster (0 - off; 1 - on)
+ * bit 2 : HEAD2 big pcluster (0 - off; 1 - on)
+ * bit 3 : tailpacking inline pcluster (0 - off; 1 - on)
+ * bit 4 : interlaced plain pcluster (0 - off; 1 - on)
+ * bit 5 : fragment pcluster (0 - off; 1 - on)
+ */
+#define Z_EROFS_ADVISE_COMPACTED_2B		0x0001
+#define Z_EROFS_ADVISE_BIG_PCLUSTER_1		0x0002
+#define Z_EROFS_ADVISE_BIG_PCLUSTER_2		0x0004
+#define Z_EROFS_ADVISE_INLINE_PCLUSTER		0x0008
+#define Z_EROFS_ADVISE_INTERLACED_PCLUSTER	0x0010
+#define Z_EROFS_ADVISE_FRAGMENT_PCLUSTER	0x0020
+
+#define Z_EROFS_FRAGMENT_INODE_BIT              7
+struct z_erofs_map_header {
+	union {
+		/* fragment data offset in the packed inode */
+		__le32  h_fragmentoff;
+		struct {
+			__le16  h_reserved1;
+			/* indicates the encoded size of tailpacking data */
+			__le16  h_idata_size;
+		};
+	};
+	__le16	h_advise;
+	/*
+	 * bit 0-3 : algorithm type of head 1 (logical cluster type 01);
+	 * bit 4-7 : algorithm type of head 2 (logical cluster type 11).
+	 */
+	__u8	h_algorithmtype;
+	/*
+	 * bit 0-2 : logical cluster bits - 12, e.g. 0 for 4096;
+	 * bit 3-6 : reserved;
+	 * bit 7   : move the whole file into packed inode or not.
+	 */
+	__u8	h_clusterbits;
+};
+
+#define Z_EROFS_VLE_LEGACY_HEADER_PADDING       8
+
+/*
+ * Fixed-sized output compression on-disk logical cluster type:
+ *    0   - literal (uncompressed) lcluster
+ *    1,3 - compressed lcluster (for HEAD lclusters)
+ *    2   - compressed lcluster (for NONHEAD lclusters)
+ *
+ * In detail,
+ *    0 - literal (uncompressed) lcluster,
+ *        di_advise = 0
+ *        di_clusterofs = the literal data offset of the lcluster
+ *        di_blkaddr = the blkaddr of the literal pcluster
+ *
+ *    1,3 - compressed lcluster (for HEAD lclusters)
+ *        di_advise = 1 or 3
+ *        di_clusterofs = the decompressed data offset of the lcluster
+ *        di_blkaddr = the blkaddr of the compressed pcluster
+ *
+ *    2 - compressed lcluster (for NONHEAD lclusters)
+ *        di_advise = 2
+ *        di_clusterofs =
+ *           the decompressed data offset in its own HEAD lcluster
+ *        di_u.delta[0] = distance to this HEAD lcluster
+ *        di_u.delta[1] = distance to the next HEAD lcluster
+ */
+enum {
+	Z_EROFS_VLE_CLUSTER_TYPE_PLAIN		= 0,
+	Z_EROFS_VLE_CLUSTER_TYPE_HEAD1		= 1,
+	Z_EROFS_VLE_CLUSTER_TYPE_NONHEAD	= 2,
+	Z_EROFS_VLE_CLUSTER_TYPE_HEAD2		= 3,
+	Z_EROFS_VLE_CLUSTER_TYPE_MAX
+};
+
+#define Z_EROFS_VLE_DI_CLUSTER_TYPE_BITS        2
+#define Z_EROFS_VLE_DI_CLUSTER_TYPE_BIT         0
+
+/* (noncompact only, HEAD) This pcluster refers to partial decompressed data */
+#define Z_EROFS_VLE_DI_PARTIAL_REF		(1 << 15)
+
+/*
+ * D0_CBLKCNT will be marked _only_ at the 1st non-head lcluster to store the
+ * compressed block count of a compressed extent (in logical clusters, aka.
+ * block count of a pcluster).
+ */
+#define Z_EROFS_VLE_DI_D0_CBLKCNT		(1 << 11)
+
+struct z_erofs_vle_decompressed_index {
+	__le16 di_advise;
+	/* where to decompress in the head lcluster */
+	__le16 di_clusterofs;
+
+	union {
+		/* for the HEAD lclusters */
+		__le32 blkaddr;
+		/*
+		 * for the NONHEAD lclusters
+		 * [0] - distance to its HEAD lcluster
+		 * [1] - distance to the next HEAD lcluster
+		 */
+		__le16 delta[2];
+	} di_u;
+};
+
+#define Z_EROFS_VLE_LEGACY_INDEX_ALIGN(size) \
+	(round_up(size, sizeof(struct z_erofs_vle_decompressed_index)) + \
+	 sizeof(struct z_erofs_map_header) + Z_EROFS_VLE_LEGACY_HEADER_PADDING)
+
+/* dirent sorts in alphabet order, thus we can do binary search */
+struct erofs_dirent {
+	__le64 nid;     /* node number */
+	__le16 nameoff; /* start offset of file name */
+	__u8 file_type; /* file type */
+	__u8 reserved;  /* reserved */
+} __packed;
+
+/*
+ * EROFS file types should match generic FT_* types and
+ * it seems no need to add BUILD_BUG_ONs since potential
+ * unmatchness will break other fses as well...
+ */
+
+#define EROFS_NAME_LEN      255
+
+/* check the EROFS on-disk layout strictly at compile time */
+static inline void erofs_check_ondisk_layout_definitions(void)
+{
+	const __le64 fmh = *(__le64 *)&(struct z_erofs_map_header) {
+		.h_clusterbits = 1 << Z_EROFS_FRAGMENT_INODE_BIT
+	};
+
+	BUILD_BUG_ON(sizeof(struct erofs_super_block) != 128);
+	BUILD_BUG_ON(sizeof(struct erofs_inode_compact) != 32);
+	BUILD_BUG_ON(sizeof(struct erofs_inode_extended) != 64);
+	BUILD_BUG_ON(sizeof(struct erofs_xattr_ibody_header) != 12);
+	BUILD_BUG_ON(sizeof(struct erofs_xattr_entry) != 4);
+	BUILD_BUG_ON(sizeof(struct erofs_inode_chunk_info) != 4);
+	BUILD_BUG_ON(sizeof(struct erofs_inode_chunk_index) != 8);
+	BUILD_BUG_ON(sizeof(struct z_erofs_map_header) != 8);
+	BUILD_BUG_ON(sizeof(struct z_erofs_vle_decompressed_index) != 8);
+	BUILD_BUG_ON(sizeof(struct erofs_dirent) != 12);
+	/* keep in sync between 2 index structures for better extendibility */
+	BUILD_BUG_ON(sizeof(struct erofs_inode_chunk_index) !=
+		     sizeof(struct z_erofs_vle_decompressed_index));
+	BUILD_BUG_ON(sizeof(struct erofs_deviceslot) != 128);
+
+	BUILD_BUG_ON(BIT(Z_EROFS_VLE_DI_CLUSTER_TYPE_BITS) <
+		     Z_EROFS_VLE_CLUSTER_TYPE_MAX - 1);
+	/* exclude old compiler versions like gcc 7.5.0 */
+	BUILD_BUG_ON(__builtin_constant_p(fmh) ?
+		     fmh != cpu_to_le64(1ULL << 63) : 0);
+}
+
+#endif

--- a/libcomposefs/erofs_fs_wrapper.h
+++ b/libcomposefs/erofs_fs_wrapper.h
@@ -1,0 +1,141 @@
+#include <linux/types.h>
+
+#define __packed                        __attribute__((__packed__))
+typedef __u8 u8;
+
+static inline __u16 cpu_to_le16(__u16 val)
+{
+	return htole16(val);
+}
+
+static inline __u32 cpu_to_le32(__u32 val)
+{
+	return htole32(val);
+}
+
+static inline __u64 cpu_to_le64(__u64 val)
+{
+	return htole64(val);
+}
+
+static inline __u16 le16_to_cpu(__u16 val)
+{
+	return le16toh(val);
+}
+
+static inline __u32 le32_to_cpu(__u32 val)
+{
+	return le32toh(val);
+}
+
+static inline __u64 le64_to_cpu(__u64 val)
+{
+	return le64toh(val);
+}
+
+#define BIT(nr)  (((uint64_t) 1) << (nr))
+#define BUILD_BUG_ON(condition) ((void)sizeof(char[1 - 2 * !!(condition)]))
+#define DIV_ROUND_UP(n, d) (((n) + (d) - 1) / (d))
+
+/* We use a fixed block size for all arches of 4k */
+#define EROFS_BLKSIZ 4096
+#define EROFS_BLKSIZ_BITS 12
+
+#define EROFS_ISLOTBITS		5
+#define EROFS_SLOTSIZE		(1U << EROFS_ISLOTBITS)
+
+#define EROFS_SUPER_MAGIC_V1 0xE0F5E1E2
+
+#define CRC32C_POLY_LE	0x82F63B78
+static inline uint32_t erofs_crc32c(uint32_t crc, const uint8_t *in, size_t len)
+{
+	int i;
+
+	while (len--) {
+		crc ^= *in++;
+		for (i = 0; i < 8; i++)
+			crc = (crc >> 1) ^ ((crc & 1) ? CRC32C_POLY_LE : 0);
+	}
+	return crc;
+}
+
+enum {
+	EROFS_FT_UNKNOWN,
+	EROFS_FT_REG_FILE,
+	EROFS_FT_DIR,
+	EROFS_FT_CHRDEV,
+	EROFS_FT_BLKDEV,
+	EROFS_FT_FIFO,
+	EROFS_FT_SOCK,
+	EROFS_FT_SYMLINK,
+	EROFS_FT_MAX
+};
+
+#define ilog2(n)			\
+(					\
+	(n) & (1ULL << 63) ? 63 :	\
+	(n) & (1ULL << 62) ? 62 :	\
+	(n) & (1ULL << 61) ? 61 :	\
+	(n) & (1ULL << 60) ? 60 :	\
+	(n) & (1ULL << 59) ? 59 :	\
+	(n) & (1ULL << 58) ? 58 :	\
+	(n) & (1ULL << 57) ? 57 :	\
+	(n) & (1ULL << 56) ? 56 :	\
+	(n) & (1ULL << 55) ? 55 :	\
+	(n) & (1ULL << 54) ? 54 :	\
+	(n) & (1ULL << 53) ? 53 :	\
+	(n) & (1ULL << 52) ? 52 :	\
+	(n) & (1ULL << 51) ? 51 :	\
+	(n) & (1ULL << 50) ? 50 :	\
+	(n) & (1ULL << 49) ? 49 :	\
+	(n) & (1ULL << 48) ? 48 :	\
+	(n) & (1ULL << 47) ? 47 :	\
+	(n) & (1ULL << 46) ? 46 :	\
+	(n) & (1ULL << 45) ? 45 :	\
+	(n) & (1ULL << 44) ? 44 :	\
+	(n) & (1ULL << 43) ? 43 :	\
+	(n) & (1ULL << 42) ? 42 :	\
+	(n) & (1ULL << 41) ? 41 :	\
+	(n) & (1ULL << 40) ? 40 :	\
+	(n) & (1ULL << 39) ? 39 :	\
+	(n) & (1ULL << 38) ? 38 :	\
+	(n) & (1ULL << 37) ? 37 :	\
+	(n) & (1ULL << 36) ? 36 :	\
+	(n) & (1ULL << 35) ? 35 :	\
+	(n) & (1ULL << 34) ? 34 :	\
+	(n) & (1ULL << 33) ? 33 :	\
+	(n) & (1ULL << 32) ? 32 :	\
+	(n) & (1ULL << 31) ? 31 :	\
+	(n) & (1ULL << 30) ? 30 :	\
+	(n) & (1ULL << 29) ? 29 :	\
+	(n) & (1ULL << 28) ? 28 :	\
+	(n) & (1ULL << 27) ? 27 :	\
+	(n) & (1ULL << 26) ? 26 :	\
+	(n) & (1ULL << 25) ? 25 :	\
+	(n) & (1ULL << 24) ? 24 :	\
+	(n) & (1ULL << 23) ? 23 :	\
+	(n) & (1ULL << 22) ? 22 :	\
+	(n) & (1ULL << 21) ? 21 :	\
+	(n) & (1ULL << 20) ? 20 :	\
+	(n) & (1ULL << 19) ? 19 :	\
+	(n) & (1ULL << 18) ? 18 :	\
+	(n) & (1ULL << 17) ? 17 :	\
+	(n) & (1ULL << 16) ? 16 :	\
+	(n) & (1ULL << 15) ? 15 :	\
+	(n) & (1ULL << 14) ? 14 :	\
+	(n) & (1ULL << 13) ? 13 :	\
+	(n) & (1ULL << 12) ? 12 :	\
+	(n) & (1ULL << 11) ? 11 :	\
+	(n) & (1ULL << 10) ? 10 :	\
+	(n) & (1ULL <<  9) ?  9 :	\
+	(n) & (1ULL <<  8) ?  8 :	\
+	(n) & (1ULL <<  7) ?  7 :	\
+	(n) & (1ULL <<  6) ?  6 :	\
+	(n) & (1ULL <<  5) ?  5 :	\
+	(n) & (1ULL <<  4) ?  4 :	\
+	(n) & (1ULL <<  3) ?  3 :	\
+	(n) & (1ULL <<  2) ?  2 :	\
+	(n) & (1ULL <<  1) ?  1 : 0	\
+)
+
+#include "erofs_fs.h"

--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -59,7 +59,6 @@ struct lcfs_node_s {
 
 	char *name;
 	char *payload; /* backing file or symlink target */
-	uint32_t inode_num;
 
 	struct lcfs_xattr_s *xattrs;
 	size_t n_xattrs;
@@ -72,6 +71,7 @@ struct lcfs_node_s {
 	/* Used during compute_tree */
 	struct lcfs_node_s *next; /* Use for the queue in compute_tree */
 	bool in_tree;
+	uint32_t inode_num;
 };
 
 struct lcfs_ctx_s {

--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -1630,6 +1630,14 @@ static int add_overlayfs_xattrs(struct lcfs_node_s *node)
 			if (ret < 0)
 				return ret;
 		}
+
+		if (node->digest_set) {
+			ret = lcfs_node_set_xattr(node, "trusted.overlay.fs-verity",
+						  (char *)node->digest,
+						  LCFS_DIGEST_SIZE);
+			if (ret < 0)
+				return ret;
+		}
 	}
 
 	return 0;

--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -59,7 +59,6 @@ struct lcfs_node_s {
 
 	char *name;
 	char *payload; /* backing file or symlink target */
-	struct lcfs_dirent_s data;
 	uint32_t inode_num;
 
 	struct lcfs_xattr_s *xattrs;

--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -38,6 +38,10 @@
 #define ALIGN_TO(_offset, _align_size)                                         \
 	(((_offset) + _align_size - 1) & ~(_align_size - 1))
 
+#define __round_mask(x, y) ((__typeof__(x))((y)-1))
+#define round_up(x, y) ((((x)-1) | __round_mask(x, y)) + 1)
+#define round_down(x, y) ((x) & ~__round_mask(x, y))
+
 /* In memory representation used to build the file.  */
 
 struct lcfs_xattr_s {
@@ -634,6 +638,15 @@ static int lcfs_write_pad(struct lcfs_ctx_s *ctx, size_t data_len)
 		}
 	}
 
+	return 0;
+}
+
+static int lcfs_write_align(struct lcfs_ctx_s *ctx, size_t align_size)
+{
+	off_t end = round_up(ctx->bytes_written, align_size);
+	if (end > ctx->bytes_written) {
+		return lcfs_write_pad(ctx, end - ctx->bytes_written);
+	}
 	return 0;
 }
 

--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -350,6 +350,11 @@ static int compute_tree(struct lcfs_ctx_s *ctx, struct lcfs_node_s *root)
 		}
 	}
 
+	/* Reset in_tree back to false for multiple uses */
+	for (node = ctx->root; node != NULL; node = node->next) {
+		node->in_tree = false;
+	}
+
 	return 0;
 }
 

--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -112,6 +112,27 @@ int lcfs_append_vdata(struct lcfs_ctx_s *ctx, struct lcfs_vdata_s *out,
 
 static int lcfs_close(struct lcfs_ctx_s *ctx);
 
+static char *maybe_join_path(const char *a, const char *b)
+{
+	size_t a_len = strlen(a);
+	size_t b_len = 0;
+
+	if (b != NULL)
+		b_len = 1 + strlen(b);
+
+	char *res = malloc(a_len + b_len + 1);
+	if (res) {
+		strcpy(res, a);
+		if (b != NULL) {
+			if (a_len > 0 && res[a_len - 1] != '/') {
+				strcat(res, "/");
+			}
+			strcat(res, b);
+		}
+	}
+	return res;
+}
+
 static char *memdup(const char *s, size_t len)
 {
 	char *s2 = malloc(len);
@@ -1426,25 +1447,6 @@ struct lcfs_node_s *lcfs_node_clone_deep(struct lcfs_node_s *node)
 bool lcfs_node_dirp(struct lcfs_node_s *node)
 {
 	return (node->inode.st_mode & S_IFMT) == S_IFDIR;
-}
-
-static char *maybe_join_path(const char *a, const char *b)
-{
-	size_t a_len = strlen(a);
-	size_t b_len = 0;
-
-	if (b != NULL)
-		b_len = 1 + strlen(b);
-
-	char *res = malloc(a_len + b_len + 1);
-	if (res) {
-		strcpy(res, a);
-		if (b != NULL) {
-			strcat(res, "/");
-			strcat(res, b);
-		}
-	}
-	return res;
 }
 
 struct lcfs_node_s *lcfs_build(int dirfd, const char *fname, const char *name,

--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -42,12 +42,17 @@
 #define round_up(x, y) ((((x)-1) | __round_mask(x, y)) + 1)
 #define round_down(x, y) ((x) & ~__round_mask(x, y))
 
+#include "erofs_fs_wrapper.h"
+
 /* In memory representation used to build the file.  */
 
 struct lcfs_xattr_s {
 	char *key;
 	char *value;
 	size_t value_len;
+
+	/* Used during writing */
+	int64_t erofs_shared_xattr_offset; /* shared offset, or -1 if not shared */
 };
 
 struct lcfs_node_s {
@@ -76,6 +81,13 @@ struct lcfs_node_s {
 	struct lcfs_node_s *next; /* Use for the queue in compute_tree */
 	bool in_tree;
 	uint32_t inode_num;
+
+	bool erofs_compact;
+	uint32_t erofs_ipad; /* padding before inode data */
+	uint32_t erofs_isize;
+	uint32_t erofs_nid;
+	uint32_t erofs_n_blocks;
+	uint32_t erofs_tailsize;
 };
 
 struct lcfs_ctx_s {
@@ -100,6 +112,13 @@ struct lcfs_ctx_s {
 	lcfs_write_cb write_cb;
 	off_t bytes_written;
 	FsVerityContext *fsverity_ctx;
+
+	uint64_t erofs_inodes_end; /* start of xattrs */
+	uint64_t erofs_shared_xattr_size;
+	uint64_t erofs_n_data_blocks;
+	uint64_t erofs_current_end;
+	struct lcfs_xattr_s **erofs_shared_xattrs;
+	size_t erofs_n_shared_xattrs;
 };
 
 #define APPEND_FLAGS_DEDUP (1 << 0)
@@ -809,9 +828,1054 @@ static int lcfs_close(struct lcfs_ctx_s *ctx)
 			lcfs_node_unref(ctx->root);
 		}
 	}
+	free(ctx->erofs_shared_xattrs);
 	free(ctx);
 
 	return 0;
+}
+
+static int erofs_make_file_type(int regular)
+{
+	switch (regular) {
+	case DT_LNK:
+		return EROFS_FT_SYMLINK;
+	case DT_DIR:
+		return EROFS_FT_DIR;
+	case DT_REG:
+		return EROFS_FT_REG_FILE;
+	case DT_BLK:
+		return EROFS_FT_BLKDEV;
+	case DT_CHR:
+		return EROFS_FT_CHRDEV;
+	case DT_SOCK:
+		return EROFS_FT_SOCK;
+	case DT_FIFO:
+		return EROFS_FT_FIFO;
+	default:
+		return EROFS_FT_UNKNOWN;
+	}
+}
+
+struct hasher_xattr_s {
+	struct lcfs_xattr_s *xattr;
+	uint32_t count;
+
+	bool shared;
+	uint64_t shared_offset; /* offset in bytes from start of shared xattrs */
+};
+
+static size_t xattrs_ht_hasher(const void *d, size_t n)
+{
+	const struct hasher_xattr_s *v = d;
+	return (hash_string(v->xattr->key, n) ^
+		hash_memory(v->xattr->value, v->xattr->value_len, n)) %
+	       n;
+}
+
+static bool xattrs_ht_comparator(const void *d1, const void *d2)
+{
+	const struct hasher_xattr_s *v1 = d1;
+	const struct hasher_xattr_s *v2 = d2;
+
+	if (strcmp(v1->xattr->key, v2->xattr->key) != 0)
+		return false;
+
+	if (v1->xattr->value_len != v2->xattr->value_len)
+		return false;
+
+	return memcmp(v1->xattr->value, v2->xattr->value, v1->xattr->value_len) == 0;
+}
+
+/* Sort alphabetically by key and value to get some canonical order */
+static int xattrs_ht_sort(const void *d1, const void *d2)
+{
+	const struct hasher_xattr_s *v1 = *(const struct hasher_xattr_s **)d1;
+	const struct hasher_xattr_s *v2 = *(const struct hasher_xattr_s **)d2;
+	int r;
+
+	r = strcmp(v2->xattr->key, v1->xattr->key);
+	if (r != 0)
+		return r;
+
+	if (v1->xattr->value_len != v2->xattr->value_len)
+		return (int)v2->xattr->value_len - (int)v1->xattr->value_len;
+
+	return memcmp(v2->xattr->value, v1->xattr->value, v1->xattr->value_len);
+}
+
+static bool str_has_prefix(const char *str, const char *prefix)
+{
+	return strncmp(str, prefix, strlen(prefix)) == 0;
+}
+
+static uint8_t xattr_erofs_entry_index(struct lcfs_xattr_s *xattr, char **rest)
+{
+	char *key = xattr->key;
+	struct {
+		const char *prefix;
+		uint8_t index;
+	} keys[] = { { "user.", EROFS_XATTR_INDEX_USER },
+		     { "system.posix_acl_access", EROFS_XATTR_INDEX_POSIX_ACL_ACCESS },
+		     { "system.posix_acl_default", EROFS_XATTR_INDEX_POSIX_ACL_DEFAULT },
+		     { "trusted.", EROFS_XATTR_INDEX_TRUSTED },
+		     { "security.", EROFS_XATTR_INDEX_SECURITY },
+		     { NULL } };
+	for (size_t i = 0; keys[i].prefix != NULL; i++) {
+		if (str_has_prefix(key, keys[i].prefix)) {
+			*rest = key + strlen(keys[i].prefix);
+			return keys[i].index;
+		}
+	}
+
+	*rest = key;
+	return 0;
+}
+
+static size_t xattr_erofs_entry_size(struct lcfs_xattr_s *xattr)
+{
+	char *key_suffix;
+	xattr_erofs_entry_index(xattr, &key_suffix);
+
+	return round_up(sizeof(struct erofs_xattr_entry) + strlen(key_suffix) +
+				xattr->value_len,
+			sizeof(uint32_t));
+}
+
+static size_t xattr_erofs_icount(size_t xattr_size)
+{
+	if (xattr_size == 0)
+		return 0;
+	return (xattr_size - sizeof(struct erofs_xattr_ibody_header)) /
+		       sizeof(uint32_t) +
+	       1;
+}
+
+static size_t xattr_erofs_inode_size(size_t n_shared_xattrs, size_t unshared_xattrs_size)
+{
+	if (n_shared_xattrs == 0 && unshared_xattrs_size == 0) {
+		return 0;
+	}
+
+	return round_up(sizeof(struct erofs_xattr_ibody_header) +
+				n_shared_xattrs * sizeof(uint32_t) +
+				unshared_xattrs_size,
+			sizeof(uint32_t));
+}
+
+static int compute_erofs_shared_xattrs(struct lcfs_ctx_s *ctx)
+{
+	struct lcfs_node_s *node;
+	Hash_table *xattr_hash;
+	struct hasher_xattr_s **sorted = NULL;
+	size_t n_xattrs;
+	uint64_t xattr_offset;
+
+	/* Find the use count for each xattr key/value in use */
+
+	xattr_hash = hash_initialize(0, NULL, xattrs_ht_hasher,
+				     xattrs_ht_comparator, free);
+	if (xattr_hash == NULL) {
+		return -1;
+	}
+
+	for (node = ctx->root; node != NULL; node = node->next) {
+		for (size_t i = 0; i < node->n_xattrs; i++) {
+			struct hasher_xattr_s hkey = { .xattr = &node->xattrs[i] };
+			struct hasher_xattr_s *ent;
+
+			ent = hash_lookup(xattr_hash, &hkey);
+			if (ent == NULL) {
+				struct hasher_xattr_s *new_ent =
+					calloc(1, sizeof(struct hasher_xattr_s));
+				if (new_ent == NULL) {
+					goto fail;
+				}
+				new_ent->xattr = &node->xattrs[i];
+				ent = hash_insert(xattr_hash, new_ent);
+				if (ent == NULL) {
+					goto fail;
+				}
+			}
+			ent->count++;
+		}
+	}
+
+	/* Compute the xattr list in canonical order */
+
+	n_xattrs = hash_get_n_entries(xattr_hash);
+	sorted = calloc(n_xattrs, sizeof(struct hasher_xattr_s *));
+	if (sorted == NULL)
+		goto fail;
+	n_xattrs = hash_get_entries(xattr_hash, (void **)sorted, n_xattrs);
+	qsort(sorted, n_xattrs, sizeof(struct hasher_xattr_s *), xattrs_ht_sort);
+
+	/* Compute the list of shared (multi-use) xattrs and their offsets */
+	ctx->erofs_shared_xattrs = calloc(n_xattrs, sizeof(struct lcfs_xattr_s *));
+	if (ctx->erofs_shared_xattrs == NULL)
+		goto fail;
+	ctx->erofs_n_shared_xattrs = 0;
+
+	xattr_offset = 0;
+	for (size_t i = 0; i < n_xattrs; i++) {
+		struct hasher_xattr_s *ent = sorted[i];
+		if (ent->count > 1) {
+			ent->shared = true;
+			ent->shared_offset = xattr_offset;
+
+			ctx->erofs_shared_xattrs[ctx->erofs_n_shared_xattrs] =
+				ent->xattr;
+			ctx->erofs_n_shared_xattrs++;
+
+			xattr_offset += xattr_erofs_entry_size(ent->xattr);
+		}
+	}
+
+	ctx->erofs_shared_xattr_size = xattr_offset;
+
+	/* Assign shared xattr offsets for all inodes */
+
+	for (node = ctx->root; node != NULL; node = node->next) {
+		int n_shared = 0;
+		for (size_t i = 0; i < node->n_xattrs; i++) {
+			struct lcfs_xattr_s *xattr = &node->xattrs[i];
+			struct hasher_xattr_s hkey = { .xattr = xattr };
+			struct hasher_xattr_s *ent;
+
+			ent = hash_lookup(xattr_hash, &hkey);
+			assert(ent != NULL);
+			if (ent->shared && n_shared < EROFS_MAX_SHARED_XATTRS) {
+				xattr->erofs_shared_xattr_offset = ent->shared_offset;
+				n_shared++;
+			} else {
+				xattr->erofs_shared_xattr_offset = -1;
+			}
+		}
+	}
+
+	free(sorted);
+	hash_free(xattr_hash);
+	return 0;
+
+fail:
+	errno = ENOMEM;
+	free(sorted);
+	hash_free(xattr_hash);
+	return -1;
+}
+
+static bool lcfs_fits_in_erofs_compact(struct lcfs_ctx_s *ctx,
+				       struct lcfs_node_s *node)
+{
+	int type = node->inode.st_mode & S_IFMT;
+	uint64_t size;
+
+	if (node->inode.st_mtim_sec != ctx->min_mtim_sec ||
+	    node->inode.st_mtim_nsec != ctx->min_mtim_nsec) {
+		return false;
+	}
+
+	if (node->inode.st_nlink > UINT16_MAX ||
+	    node->inode.st_uid > UINT16_MAX || node->inode.st_gid > UINT16_MAX) {
+		return false;
+	}
+
+	if (type == S_IFDIR) {
+		size = (uint64_t)node->erofs_n_blocks * EROFS_BLKSIZ +
+		       node->erofs_tailsize;
+	} else {
+		size = node->inode.st_size;
+	}
+	if (size > UINT32_MAX) {
+		return false;
+	}
+
+	return true;
+}
+
+static void compute_erofs_dir_size(struct lcfs_node_s *node)
+{
+	uint32_t n_blocks = 0;
+	size_t block_size = 0;
+
+	for (size_t i = 0; i < node->children_size; i++) {
+		struct lcfs_node_s *child = node->children[i];
+		size_t len = sizeof(struct erofs_dirent) + strlen(child->name);
+		if (block_size + len > EROFS_BLKSIZ) {
+			n_blocks++;
+			block_size = 0;
+		}
+		block_size += len;
+	}
+
+	/* As a heuristic, we never inline more than half a block */
+	if (block_size > EROFS_BLKSIZ / 2) {
+		n_blocks++;
+		block_size = 0;
+	}
+
+	node->erofs_n_blocks = n_blocks;
+	node->erofs_tailsize = block_size;
+}
+
+static uint32_t compute_erofs_chunk_bitsize(struct lcfs_node_s *node)
+{
+	uint64_t file_size = node->inode.st_size;
+
+	// Compute the chunksize to use for the file size
+	// We want as few chunks as possible, but not an
+	// unnecessary large chunk.
+	uint32_t chunkbits = ilog2(file_size - 1) + 1;
+
+	// At least one logical block
+	if (chunkbits < EROFS_BLKSIZ_BITS)
+		chunkbits = EROFS_BLKSIZ_BITS;
+
+	// Not larger chunks than max possible
+	if (chunkbits - EROFS_BLKSIZ_BITS > EROFS_CHUNK_FORMAT_BLKBITS_MASK)
+		chunkbits = EROFS_CHUNK_FORMAT_BLKBITS_MASK + EROFS_BLKSIZ_BITS;
+
+	return chunkbits;
+}
+
+static void compute_erofs_inode_size(struct lcfs_node_s *node)
+{
+	int type = node->inode.st_mode & S_IFMT;
+	uint64_t file_size = node->inode.st_size;
+
+	if (type == S_IFDIR) {
+		compute_erofs_dir_size(node);
+	} else if (type == S_IFLNK) {
+		node->erofs_n_blocks = 0;
+		node->erofs_tailsize = strlen(node->payload);
+	} else if (type == S_IFREG && file_size > 0) {
+		uint32_t chunkbits = compute_erofs_chunk_bitsize(node);
+		uint64_t chunksize = 1ULL << chunkbits;
+		uint32_t chunk_count = DIV_ROUND_UP(file_size, chunksize);
+
+		node->erofs_n_blocks = 0;
+		node->erofs_tailsize = chunk_count * sizeof(uint32_t);
+	} else {
+		node->erofs_n_blocks = 0;
+		node->erofs_tailsize = 0;
+	}
+}
+
+static void compute_erofs_xattr_counts(struct lcfs_node_s *node,
+				       size_t *n_shared_xattrs_out,
+				       size_t *unshared_xattrs_size_out)
+{
+	size_t n_shared_xattrs = 0;
+	size_t unshared_xattrs_size = 0;
+
+	for (size_t i = 0; i < node->n_xattrs; i++) {
+		struct lcfs_xattr_s *xattr = &node->xattrs[i];
+		if (xattr->erofs_shared_xattr_offset >= 0) {
+			n_shared_xattrs++;
+		} else {
+			unshared_xattrs_size += xattr_erofs_entry_size(xattr);
+		}
+	}
+
+	*n_shared_xattrs_out = n_shared_xattrs;
+	*unshared_xattrs_size_out = unshared_xattrs_size;
+}
+
+static uint64_t compute_erofs_inode_padding_for_tail(struct lcfs_node_s *node,
+						     uint64_t pos, size_t inode_size,
+						     size_t xattr_size)
+{
+	int type = node->inode.st_mode & S_IFMT;
+	uint64_t block_remainder;
+	size_t non_tail_size = inode_size + xattr_size;
+	size_t total_size = inode_size + xattr_size + node->erofs_tailsize;
+
+	/* This adds extra padding in front of an inode to ensure that
+	 * the tail data doesn't cross a block boundary.
+	 */
+
+	if (type == S_IFLNK) {
+		/* Due to how erofs_fill_symlink is implemented, we
+		 * need *both* the inode data and the symlink tail
+		 * data in the same block, wheras normally just the
+		 * tail data itself need to be inside a block.
+		 */
+		if (pos / EROFS_BLKSIZ != (pos + total_size - 1) / EROFS_BLKSIZ) {
+			return round_up(pos, EROFS_BLKSIZ) - pos;
+		}
+		return 0;
+	}
+
+	block_remainder = EROFS_BLKSIZ - ((pos + non_tail_size) % EROFS_BLKSIZ);
+	if (block_remainder < node->erofs_tailsize) {
+		/* Add (aligned) padding so that tail starts in new block */
+		uint64_t extra_pad = round_up(block_remainder, EROFS_SLOTSIZE);
+
+		/* Due to the extra_pad round up it is possible the tail does not fit anyway */
+		block_remainder = EROFS_BLKSIZ -
+				  ((pos + non_tail_size + extra_pad) % EROFS_BLKSIZ);
+		if (node->erofs_tailsize <= block_remainder) {
+			/* It fit! */
+			return extra_pad;
+		}
+		/* Didn't fit, don't inline the tail. */
+		node->erofs_n_blocks++;
+		node->erofs_tailsize = 0;
+	}
+
+	return 0;
+}
+
+static int compute_erofs_inodes(struct lcfs_ctx_s *ctx)
+{
+	struct lcfs_node_s *node;
+	uint64_t pos, ppos;
+	uint64_t meta_start, extra_pad;
+
+	// Start inode data directly after superblock
+	pos = EROFS_SUPER_OFFSET + sizeof(struct erofs_super_block);
+
+	// But inode offsets (nids) are relative to start of block
+	meta_start = round_down(pos, EROFS_BLKSIZ);
+
+	for (node = ctx->root; node != NULL; node = node->next) {
+		size_t n_shared_xattrs, unshared_xattrs_size;
+		size_t inode_size, xattr_size;
+
+		compute_erofs_inode_size(node);
+		node->erofs_compact = lcfs_fits_in_erofs_compact(ctx, node);
+		inode_size = node->erofs_compact ?
+				     sizeof(struct erofs_inode_compact) :
+				     sizeof(struct erofs_inode_extended);
+
+		compute_erofs_xattr_counts(node, &n_shared_xattrs,
+					   &unshared_xattrs_size);
+		xattr_size = xattr_erofs_inode_size(n_shared_xattrs,
+						    unshared_xattrs_size);
+
+		/* Align inode start to next slot */
+		ppos = pos;
+		pos = round_up(pos, EROFS_SLOTSIZE);
+		node->erofs_ipad = pos - ppos;
+
+		/* Ensure tail does not straddle block boundaries */
+		extra_pad = compute_erofs_inode_padding_for_tail(
+			node, pos, inode_size, xattr_size);
+		node->erofs_ipad += extra_pad;
+		pos += extra_pad;
+
+		node->erofs_isize = inode_size + xattr_size + node->erofs_tailsize;
+		ctx->erofs_n_data_blocks += node->erofs_n_blocks;
+		node->erofs_nid = (pos - meta_start) / EROFS_SLOTSIZE;
+
+		/* Assert that tails never span multiple blocks */
+		assert(node->erofs_tailsize == 0 ||
+		       ((pos + inode_size + xattr_size) / EROFS_BLKSIZ) ==
+			       ((pos + node->erofs_isize - 1) / EROFS_BLKSIZ));
+
+		pos += node->erofs_isize;
+	}
+
+	ctx->erofs_inodes_end = round_up(pos, EROFS_SLOTSIZE);
+
+	return 0;
+}
+
+static int write_erofs_xattr(struct lcfs_ctx_s *ctx, struct lcfs_xattr_s *xattr)
+{
+	struct erofs_xattr_entry e = { 0 };
+	int ret;
+	char *key_suffix;
+	uint8_t index = xattr_erofs_entry_index(xattr, &key_suffix);
+
+	e.e_name_len = strlen(key_suffix);
+	e.e_name_index = index;
+	e.e_value_size = lcfs_u16_to_file(xattr->value_len);
+
+	ret = lcfs_write(ctx, &e, sizeof(e));
+	if (ret < 0)
+		return ret;
+
+	ret = lcfs_write(ctx, key_suffix, strlen(key_suffix));
+	if (ret < 0)
+		return ret;
+
+	ret = lcfs_write(ctx, xattr->value, xattr->value_len);
+	if (ret < 0)
+		return ret;
+
+	return lcfs_write_align(ctx, sizeof(uint32_t));
+}
+
+static int write_erofs_dentries_chunk(struct lcfs_ctx_s *ctx,
+				      struct lcfs_node_s *node, int first_child,
+				      int n_children, int alignment)
+{
+	uint16_t nameoff = n_children * sizeof(struct erofs_dirent);
+	int ret;
+
+	for (size_t i = first_child; i < first_child + n_children; i++) {
+		struct lcfs_node_s *dirent_child = node->children[i];
+		struct lcfs_node_s *target_child = follow_links(dirent_child);
+
+		struct erofs_dirent dirent = { 0 };
+		dirent.nid = lcfs_u64_to_file(target_child->erofs_nid);
+		dirent.nameoff = lcfs_u16_to_file(nameoff);
+		dirent.file_type =
+			erofs_make_file_type(node_get_dtype(target_child));
+
+		nameoff += strlen(dirent_child->name);
+
+		ret = lcfs_write(ctx, &dirent, sizeof(dirent));
+		if (ret < 0)
+			return ret;
+	}
+
+	for (size_t i = first_child; i < first_child + n_children; i++) {
+		struct lcfs_node_s *dirent_child = node->children[i];
+
+		ret = lcfs_write(ctx, dirent_child->name, strlen(dirent_child->name));
+		if (ret < 0)
+			return ret;
+	}
+
+	return lcfs_write_align(ctx, alignment);
+}
+
+static int write_erofs_dentries(struct lcfs_ctx_s *ctx, struct lcfs_node_s *node,
+				bool write_blocks, bool write_tail)
+{
+	size_t block_size = 0;
+	size_t block_written = 0;
+	size_t first = 0;
+	int ret;
+
+	for (size_t i = 0; i < node->children_size; i++) {
+		struct lcfs_node_s *child = node->children[i];
+		size_t len = sizeof(struct erofs_dirent) + strlen(child->name);
+		if (block_size + len > EROFS_BLKSIZ) {
+			if (write_blocks) {
+				ret = write_erofs_dentries_chunk(
+					ctx, node, first, i - first, EROFS_BLKSIZ);
+				if (ret < 0)
+					return ret;
+			}
+
+			block_written++;
+			block_size = 0;
+			first = i;
+		}
+		block_size += len;
+	}
+
+	/* Handle the remaining block which is either tailpacked or block as decided before */
+
+	if (block_written < node->erofs_n_blocks) {
+		if (write_blocks) {
+			ret = write_erofs_dentries_chunk(ctx, node, first,
+							 node->children_size - first,
+							 EROFS_BLKSIZ);
+			if (ret < 0)
+				return ret;
+		}
+
+		block_written++;
+		block_size = 0;
+		first = node->children_size;
+	}
+
+	if (write_tail && block_size > 0) {
+		ret = write_erofs_dentries_chunk(ctx, node, first,
+						 node->children_size - first, 1);
+		if (ret < 0)
+			return ret;
+	}
+
+	return 0;
+}
+
+static int write_erofs_inode_data(struct lcfs_ctx_s *ctx, struct lcfs_node_s *node)
+{
+	int type = node->inode.st_mode & S_IFMT;
+	size_t xattr_icount;
+	uint64_t size;
+	int ret;
+	uint16_t format;
+	uint16_t version;
+	uint16_t datalayout;
+	off_t orig_bytes_written = ctx->bytes_written;
+	size_t n_shared_xattrs;
+	size_t unshared_xattrs_size;
+	size_t xattr_size;
+	uint32_t chunk_count = 0;
+	uint16_t chunk_format = 0;
+
+	ret = lcfs_write_pad(ctx, node->erofs_ipad);
+	if (ret < 0)
+		return ret;
+
+	/* All inodes start on slot boundary */
+	assert(ctx->bytes_written % EROFS_SLOTSIZE == 0);
+
+	/* compute xattr details */
+
+	compute_erofs_xattr_counts(node, &n_shared_xattrs, &unshared_xattrs_size);
+	xattr_size = xattr_erofs_inode_size(n_shared_xattrs, unshared_xattrs_size);
+	xattr_icount = xattr_erofs_icount(xattr_size);
+
+	version = node->erofs_compact ? 0 : 1;
+	datalayout = (node->erofs_tailsize > 0) ? EROFS_INODE_FLAT_INLINE :
+						  EROFS_INODE_FLAT_PLAIN;
+
+	if (type == S_IFDIR || type == S_IFLNK) {
+		size = (uint64_t)node->erofs_n_blocks * EROFS_BLKSIZ +
+		       node->erofs_tailsize;
+	} else if (type == S_IFREG) {
+		size = node->inode.st_size;
+
+		if (size > 0) {
+			uint32_t chunkbits = compute_erofs_chunk_bitsize(node);
+			uint64_t chunksize = 1ULL << chunkbits;
+
+			datalayout = EROFS_INODE_CHUNK_BASED;
+			chunk_count = DIV_ROUND_UP(size, chunksize);
+			chunk_format = chunkbits - EROFS_BLKSIZ_BITS;
+		}
+	} else {
+		size = 0;
+	}
+
+	format = datalayout << EROFS_I_DATALAYOUT_BIT | version << EROFS_I_VERSION_BIT;
+
+	if (node->erofs_compact) {
+		struct erofs_inode_compact i = { lcfs_u16_to_file(format) };
+		i.i_xattr_icount = lcfs_u16_to_file(xattr_icount);
+		i.i_mode = lcfs_u16_to_file(node->inode.st_mode);
+		i.i_nlink = lcfs_u16_to_file(node->inode.st_nlink);
+		i.i_size = lcfs_u32_to_file(size);
+		i.i_ino = lcfs_u32_to_file(node->inode_num);
+		i.i_uid = lcfs_u16_to_file(node->inode.st_uid);
+		i.i_gid = lcfs_u16_to_file(node->inode.st_gid);
+
+		if (type == S_IFDIR) {
+			if (node->erofs_n_blocks > 0) {
+				i.i_u.raw_blkaddr =
+					ctx->erofs_current_end / EROFS_BLKSIZ;
+				ctx->erofs_current_end +=
+					EROFS_BLKSIZ * node->erofs_n_blocks;
+			}
+		} else if (type == S_IFCHR || type == S_IFBLK) {
+			i.i_u.rdev = lcfs_u32_to_file(node->inode.st_rdev);
+		} else if (type == S_IFREG) {
+			if (datalayout == EROFS_INODE_CHUNK_BASED) {
+				i.i_u.c.format = lcfs_u16_to_file(chunk_format);
+			}
+		}
+
+		ret = lcfs_write(ctx, &i, sizeof(i));
+		if (ret < 0)
+			return ret;
+	} else {
+		struct erofs_inode_extended i = { lcfs_u16_to_file(format) };
+		i.i_xattr_icount = lcfs_u16_to_file(xattr_icount);
+		i.i_mode = lcfs_u16_to_file(node->inode.st_mode);
+		i.i_nlink = lcfs_u32_to_file(node->inode.st_nlink);
+		i.i_size = lcfs_u64_to_file(size);
+		i.i_ino = lcfs_u32_to_file(node->inode_num);
+		i.i_uid = lcfs_u32_to_file(node->inode.st_uid);
+		i.i_gid = lcfs_u32_to_file(node->inode.st_gid);
+		i.i_mtime = lcfs_u64_to_file(node->inode.st_mtim_sec);
+		i.i_mtime_nsec = lcfs_u64_to_file(node->inode.st_mtim_nsec);
+
+		if (type == S_IFDIR) {
+			if (node->erofs_n_blocks > 0) {
+				i.i_u.raw_blkaddr =
+					ctx->erofs_current_end / EROFS_BLKSIZ;
+				ctx->erofs_current_end +=
+					EROFS_BLKSIZ * node->erofs_n_blocks;
+			}
+		} else if (type == S_IFCHR || type == S_IFBLK) {
+			i.i_u.rdev = lcfs_u32_to_file(node->inode.st_rdev);
+		} else if (type == S_IFREG) {
+			if (datalayout == EROFS_INODE_CHUNK_BASED) {
+				i.i_u.c.format = lcfs_u16_to_file(chunk_format);
+			}
+		}
+
+		ret = lcfs_write(ctx, &i, sizeof(i));
+		if (ret < 0)
+			return ret;
+	}
+
+	/* write xattrs */
+	if (xattr_size) {
+		struct erofs_xattr_ibody_header xattr_header = { 0 };
+		xattr_header.h_shared_count = n_shared_xattrs;
+
+		ret = lcfs_write(ctx, &xattr_header, sizeof(xattr_header));
+		if (ret < 0)
+			return ret;
+
+		/* shared */
+		for (size_t i = 0; i < node->n_xattrs; i++) {
+			struct lcfs_xattr_s *xattr = &node->xattrs[i];
+			if (xattr->erofs_shared_xattr_offset >= 0) {
+				uint64_t offset =
+					ctx->erofs_inodes_end % EROFS_BLKSIZ +
+					xattr->erofs_shared_xattr_offset;
+				uint32_t v =
+					lcfs_u32_to_file(offset / sizeof(uint32_t));
+				ret = lcfs_write(ctx, &v, sizeof(v));
+				if (ret < 0)
+					return ret;
+			}
+		}
+		/* unshared */
+		for (size_t i = 0; i < node->n_xattrs; i++) {
+			struct lcfs_xattr_s *xattr = &node->xattrs[i];
+			if (xattr->erofs_shared_xattr_offset < 0) {
+				ret = write_erofs_xattr(ctx, xattr);
+				if (ret < 0)
+					return ret;
+			}
+		}
+	}
+
+	if (type == S_IFDIR) {
+		ret = write_erofs_dentries(ctx, node, false, true);
+		if (ret < 0)
+			return ret;
+	} else if (type == S_IFLNK) {
+		ret = lcfs_write(ctx, node->payload, strlen(node->payload));
+		if (ret < 0)
+			return ret;
+	} else if (type == S_IFREG) {
+		for (size_t i = 0; i < chunk_count; i++) {
+			uint32_t empty_chunk = 0xFFFFFFFF;
+			ret = lcfs_write(ctx, &empty_chunk, sizeof(empty_chunk));
+			if (ret < 0)
+				return ret;
+		}
+	}
+
+	assert(ctx->bytes_written - orig_bytes_written ==
+	       node->erofs_isize + node->erofs_ipad);
+
+	return 0;
+}
+
+static int write_erofs_inodes(struct lcfs_ctx_s *ctx)
+{
+	struct lcfs_node_s *node;
+	int ret;
+
+	for (node = ctx->root; node != NULL; node = node->next) {
+		ret = write_erofs_inode_data(ctx, node);
+		if (ret < 0)
+			return ret;
+	}
+
+	ret = lcfs_write_align(ctx, EROFS_SLOTSIZE);
+	if (ret < 0)
+		return ret;
+
+	return 0;
+}
+
+static int write_erofs_dirent_blocks(struct lcfs_ctx_s *ctx)
+{
+	struct lcfs_node_s *node;
+	int ret;
+
+	for (node = ctx->root; node != NULL; node = node->next) {
+		ret = write_erofs_dentries(ctx, node, true, false);
+		if (ret < 0)
+			return ret;
+	}
+
+	return 0;
+}
+
+static int write_erofs_shared_xattrs(struct lcfs_ctx_s *ctx)
+{
+	int ret;
+
+	for (size_t i = 0; i < ctx->erofs_n_shared_xattrs; i++) {
+		struct lcfs_xattr_s *xattr = ctx->erofs_shared_xattrs[i];
+		ret = write_erofs_xattr(ctx, xattr);
+		if (ret < 0)
+			return ret;
+	}
+
+	return 0;
+}
+
+static int add_overlayfs_xattrs(struct lcfs_node_s *node)
+{
+	int ret;
+
+	if ((node->inode.st_mode & S_IFMT) == S_IFREG && node->inode.st_size > 0) {
+		ret = lcfs_node_set_xattr(node, "trusted.overlay.metacopy", "", 0);
+		if (ret < 0)
+			return ret;
+
+		if (strlen(node->payload) > 0) {
+			char *path = maybe_join_path("/", node->payload);
+			if (path == NULL) {
+				errno = ENOMEM;
+				return -1;
+			}
+			ret = lcfs_node_set_xattr(node, "trusted.overlay.redirect",
+						  path, strlen(path));
+			free(path);
+			if (ret < 0)
+				return ret;
+		}
+	}
+
+	return 0;
+}
+
+static int add_overlay_whiteouts(struct lcfs_node_s *root)
+{
+	static const char hexchars[] = "0123456789abcdef";
+	const char *selinux;
+	size_t selinux_len;
+	int res;
+
+	selinux = lcfs_node_get_xattr(root, "security.selinux", &selinux_len);
+
+	for (int i = 0; i <= 255; i++) {
+		struct lcfs_node_s *child;
+		char name[3];
+
+		name[0] = hexchars[(i >> 4) % 16];
+		name[1] = hexchars[i % 16];
+		name[2] = 0;
+
+		child = lcfs_node_lookup_child(root, name);
+		if (child != NULL)
+			continue;
+
+		child = lcfs_node_new();
+		if (child == NULL) {
+			errno = ENOMEM;
+			return -1;
+		}
+
+		lcfs_node_set_mode(child, S_IFCHR | 0644);
+		lcfs_node_set_rdev(child, 0);
+
+		child->inode.st_uid = root->inode.st_uid;
+		child->inode.st_gid = root->inode.st_gid;
+		child->inode.st_mtim_sec = root->inode.st_mtim_sec;
+		child->inode.st_mtim_nsec = root->inode.st_mtim_nsec;
+		child->inode.st_ctim_sec = root->inode.st_ctim_sec;
+		child->inode.st_ctim_nsec = root->inode.st_ctim_nsec;
+
+		/* Inherit selinux context from root dir */
+		if (selinux != NULL) {
+			res = lcfs_node_set_xattr(child, "security.selinux",
+						  selinux, selinux_len);
+			if (res < 0)
+				return res;
+		}
+
+		res = lcfs_node_add_child(root, child, name);
+		if (res < 0)
+			return res;
+	}
+
+	return 0;
+}
+
+static int rewrite_tree_node_for_erofs(struct lcfs_node_s *node,
+				       struct lcfs_node_s *parent)
+{
+	int ret;
+
+	ret = add_overlayfs_xattrs(node);
+	if (ret < 0)
+		return ret;
+
+	if (lcfs_node_dirp(node)) {
+		struct lcfs_node_s *existing;
+
+		/* Ensure we have . and .. */
+		existing = lcfs_node_lookup_child(node, ".");
+		if (existing == NULL) {
+			struct lcfs_node_s *link = lcfs_node_new();
+			if (link == NULL) {
+				errno = ENOMEM;
+				return -1;
+			}
+			lcfs_node_make_hardlink(link, node);
+			ret = lcfs_node_add_child(node, link, ".");
+			if (ret < 0) {
+				lcfs_node_unref(link);
+				return -1;
+			}
+		}
+
+		existing = lcfs_node_lookup_child(node, "..");
+		if (existing == NULL) {
+			struct lcfs_node_s *link = lcfs_node_new();
+			if (link == NULL) {
+				errno = ENOMEM;
+				return -1;
+			}
+			lcfs_node_make_hardlink(link, parent);
+			ret = lcfs_node_add_child(node, link, "..");
+			if (ret < 0) {
+				lcfs_node_unref(link);
+				return -1;
+			}
+		}
+
+		for (size_t i = 0; i < node->children_size; ++i) {
+			struct lcfs_node_s *child = node->children[i];
+
+			if (child->link_to != NULL) {
+				continue;
+			}
+
+			ret = rewrite_tree_node_for_erofs(child, node);
+			if (ret < 0) {
+				return -1;
+			}
+		}
+	}
+
+	return 0;
+}
+
+static int rewrite_tree_for_erofs(struct lcfs_node_s *root)
+{
+	int res;
+
+	res = rewrite_tree_node_for_erofs(root, root);
+	if (res < 0)
+		return res;
+
+	res = add_overlay_whiteouts(root);
+	if (res < 0)
+		return res;
+
+	return 0;
+}
+
+int lcfs_write_erofs_to(struct lcfs_node_s *root, void *file,
+			lcfs_write_cb write_cb, uint8_t *digest_out)
+{
+	struct erofs_super_block superblock = {
+		.magic = lcfs_u32_to_file(EROFS_SUPER_MAGIC_V1),
+		.blkszbits = EROFS_BLKSIZ_BITS,
+	};
+	int ret = 0;
+	struct lcfs_ctx_s *ctx;
+	uint64_t data_block_start;
+
+	/* Clone root so we can make required modifications to it */
+	ctx = lcfs_new_ctx(root, true, file, write_cb, digest_out);
+	if (ctx == NULL) {
+		errno = ENOMEM;
+		return -1;
+	}
+
+	root = ctx->root; /* We cloned it */
+
+	/* Rewrite cloned tree as needed for erofs */
+	ret = rewrite_tree_for_erofs(root);
+	if (ret < 0)
+		goto fail;
+
+	ret = compute_tree(ctx, root);
+	if (ret < 0)
+		goto fail;
+
+	ret = compute_erofs_shared_xattrs(ctx);
+	if (ret < 0)
+		goto fail;
+
+	ret = compute_erofs_inodes(ctx);
+	if (ret < 0)
+		goto fail;
+
+	ret = lcfs_write_pad(ctx, EROFS_SUPER_OFFSET);
+	if (ret < 0)
+		goto fail;
+
+	superblock.feature_compat = lcfs_u32_to_file(EROFS_FEATURE_COMPAT_MTIME);
+	superblock.inos = lcfs_u64_to_file(ctx->num_inodes);
+
+	superblock.build_time = lcfs_u64_to_file(ctx->min_mtim_sec);
+	superblock.build_time_nsec = lcfs_u32_to_file(ctx->min_mtim_nsec);
+
+	/* metadata is stored directly after superblock */
+	superblock.meta_blkaddr = lcfs_u32_to_file(
+		(EROFS_SUPER_OFFSET + sizeof(superblock)) / EROFS_BLKSIZ);
+	assert(root->erofs_nid < UINT16_MAX);
+	superblock.root_nid = lcfs_u16_to_file(root->erofs_nid);
+
+	/* shared xattrs is directly after metadata */
+	superblock.xattr_blkaddr =
+		lcfs_u32_to_file(ctx->erofs_inodes_end / EROFS_BLKSIZ);
+
+	data_block_start =
+		round_up(ctx->erofs_inodes_end + ctx->erofs_shared_xattr_size,
+			 EROFS_BLKSIZ);
+
+	superblock.blocks = lcfs_u32_to_file(data_block_start / EROFS_BLKSIZ +
+					     ctx->erofs_n_data_blocks);
+
+	/* TODO: More superblock fields:
+	 *  uuid?
+	 *  volume_name?
+	 */
+
+	ret = lcfs_write(ctx, &superblock, sizeof(superblock));
+	if (ret < 0)
+		goto fail;
+
+	ctx->erofs_current_end = data_block_start;
+
+	ret = write_erofs_inodes(ctx);
+	if (ret < 0)
+		goto fail;
+
+	assert(ctx->erofs_inodes_end == ctx->bytes_written);
+
+	ret = write_erofs_shared_xattrs(ctx);
+	if (ret < 0)
+		goto fail;
+
+	assert(ctx->erofs_inodes_end + ctx->erofs_shared_xattr_size ==
+	       ctx->bytes_written);
+
+	/* Following are full blocks and must be block-aligned */
+	ret = lcfs_write_align(ctx, EROFS_BLKSIZ);
+	if (ret < 0)
+		goto fail;
+
+	assert(data_block_start == ctx->bytes_written);
+
+	ret = write_erofs_dirent_blocks(ctx);
+	if (ret < 0)
+		goto fail;
+
+	assert(ctx->erofs_current_end == ctx->bytes_written);
+	assert(data_block_start + ctx->erofs_n_data_blocks * EROFS_BLKSIZ ==
+	       ctx->bytes_written);
+
+	if (digest_out) {
+		lcfs_fsverity_context_get_digest(ctx->fsverity_ctx, digest_out);
+	}
+
+	lcfs_close(ctx);
+	return 0;
+
+fail:
+	lcfs_close(ctx);
+	return -1;
 }
 
 static int read_xattrs(struct lcfs_node_s *ret, int dirfd, const char *fname)

--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -387,6 +387,18 @@ static int compute_tree(struct lcfs_ctx_s *ctx, struct lcfs_node_s *root)
 		}
 	}
 
+	/* Ensure all hardlinks are in tree */
+	for (node = ctx->root; node != NULL; node = node->next) {
+		for (size_t i = 0; i < node->children_size; i++) {
+			struct lcfs_node_s *child = node->children[i];
+			if (child->link_to != NULL && !child->link_to->in_tree) {
+				/* Link to inode outside tree */
+				errno = EINVAL;
+				return -1;
+			}
+		}
+	}
+
 	/* Reset in_tree back to false for multiple uses */
 	for (node = ctx->root; node != NULL; node = node->next) {
 		node->in_tree = false;

--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -349,7 +349,7 @@ static int compute_tree(struct lcfs_ctx_s *ctx, struct lcfs_node_s *root)
 			struct lcfs_node_s *child = node->children[i];
 
 			/* Skip hardlinks, they will not be serialized separately */
-			if (node->link_to != NULL) {
+			if (child->link_to != NULL) {
 				continue;
 			}
 

--- a/libcomposefs/lcfs-writer.h
+++ b/libcomposefs/lcfs-writer.h
@@ -39,6 +39,8 @@ typedef ssize_t (*lcfs_write_cb)(void *file, void *buf, size_t count);
 struct lcfs_node_s *lcfs_node_new(void);
 struct lcfs_node_s *lcfs_node_ref(struct lcfs_node_s *node);
 void lcfs_node_unref(struct lcfs_node_s *node);
+struct lcfs_node_s *lcfs_node_clone(struct lcfs_node_s *node);
+struct lcfs_node_s *lcfs_node_clone_deep(struct lcfs_node_s *node);
 struct lcfs_node_s *lcfs_load_node_from_file(int dirfd, const char *fname,
 					     int buildflags);
 

--- a/libcomposefs/lcfs-writer.h
+++ b/libcomposefs/lcfs-writer.h
@@ -98,4 +98,7 @@ struct lcfs_node_s *lcfs_build(int dirfd, const char *fname, const char *name,
 int lcfs_write_to(struct lcfs_node_s *root, void *file, lcfs_write_cb write_cb,
 		  uint8_t *digest_out);
 
+int lcfs_write_erofs_to(struct lcfs_node_s *root, void *file,
+			lcfs_write_cb write_cb, uint8_t *digest_out);
+
 #endif

--- a/tools/mkcomposefs.c
+++ b/tools/mkcomposefs.c
@@ -233,6 +233,16 @@ static int copy_file_with_dirs_if_needed(const char *src, const char *dst_base,
 	}
 	close(sfd);
 
+	/* Make sure file is readable by all */
+	res = fchmod(dfd, 0644);
+	if (res < 0) {
+		errsv = errno;
+		unlink(tmppath);
+		close(dfd);
+		errno = errsv;
+		return res;
+	}
+
 	res = fsync(dfd);
 	if (res < 0) {
 		errsv = errno;

--- a/tools/mkcomposefs.c
+++ b/tools/mkcomposefs.c
@@ -366,6 +366,7 @@ static void usage(const char *argv0)
 #define OPT_BY_DIGEST 107
 #define OPT_DIGEST_STORE 108
 #define OPT_PRINT_DIGEST 109
+#define OPT_FORMAT 110
 
 static ssize_t write_cb(void *_file, void *buf, size_t count)
 {
@@ -425,6 +426,12 @@ int main(int argc, char **argv)
 			flag: NULL,
 			val: OPT_PRINT_DIGEST
 		},
+		{
+			name: "format",
+			has_arg: required_argument,
+			flag: NULL,
+			val: OPT_FORMAT
+		},
 		{},
 	};
 	const char *bin = argv[0];
@@ -432,6 +439,7 @@ int main(int argc, char **argv)
 	bool absolute_path = false;
 	bool by_digest = false;
 	bool print_digest = false;
+	const char *format = "composefs";
 	struct lcfs_node_s *root;
 	const char *out = NULL;
 	const char *dir_path = NULL;
@@ -465,6 +473,9 @@ int main(int argc, char **argv)
 			break;
 		case OPT_DIGEST_STORE:
 			digest_store_path = optarg;
+			break;
+		case OPT_FORMAT:
+			format = optarg;
 			break;
 		case OPT_PRINT_DIGEST:
 			print_digest = true;
@@ -557,8 +568,17 @@ int main(int argc, char **argv)
 			 by_digest, digest_store_path) < 0)
 		error(EXIT_FAILURE, errno, "cannot fill payload");
 
-	if (lcfs_write_to(root, out_file, write_cb, print_digest ? digest : NULL) < 0)
-		error(EXIT_FAILURE, errno, "cannot write to stdout");
+	if (strcmp(format, "erofs") == 0) {
+		if (lcfs_write_erofs_to(root, out_file, write_cb,
+					print_digest ? digest : NULL) < 0)
+			error(EXIT_FAILURE, errno, "cannot write file");
+	} else if (strcmp(format, "composefs") == 0) {
+		if (lcfs_write_to(root, out_file, write_cb,
+				  print_digest ? digest : NULL) < 0)
+			error(EXIT_FAILURE, errno, "cannot write file");
+	} else {
+		error(EXIT_FAILURE, errno, "Unknown format %s", format);
+	}
 
 	if (print_digest) {
 		char digest_str[LCFS_DIGEST_SIZE * 2 + 1] = { 0 };


### PR DESCRIPTION
This adds support for --format=erofs to generate an erofs image designed to be used in combination with overlayfs.