### PR TITLE
Create mount.composefs helper

### DIFF
--- a/libcomposefs/Makefile-lib.am
+++ b/libcomposefs/Makefile-lib.am
@@ -9,6 +9,8 @@ libcomposefs_la_SOURCES = \
                         $(COMPOSEFSDIR)/lcfs-fsvertiy.h \
                         $(COMPOSEFSDIR)/lcfs-writer.c \
                         $(COMPOSEFSDIR)/lcfs-writer.h \
+                        $(COMPOSEFSDIR)/lcfs-mount.c \
+                        $(COMPOSEFSDIR)/lcfs-mount.h \
                         $(COMPOSEFSDIR)/xalloc-oversized.h
 libcomposefs_la_CFLAGS = $(WARN_CFLAGS) $(COMPOSEFS_HASH_CFLAGS) $(LCFS_DEP_CRYPTO_CFLAGS)
 libcomposefs_la_LIBADD = $(LCFS_DEP_CRYPTO_LIBS)

--- a/libcomposefs/lcfs-mount.c
+++ b/libcomposefs/lcfs-mount.c
@@ -1,0 +1,392 @@
+/* lcfs
+   Copyright (C) 2023 Alexander Larsson <alexl@redhat.com>
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#define _GNU_SOURCE
+
+#include "config.h"
+
+#include "lcfs.h"
+#include "lcfs-mount.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <sys/mount.h>
+#include <sys/types.h>
+#include <linux/limits.h>
+#include <linux/loop.h>
+#include <linux/mount.h>
+#include <linux/fsverity.h>
+
+#include "lcfs-erofs.h"
+
+#define MAX_DIGEST_SIZE 64
+
+struct lcfs_mount_state_s {
+	const char *image_path;
+	const char *mountpoint;
+	struct lcfs_mount_options_s *options;
+	int fd;
+	uint8_t expected_digest[MAX_DIGEST_SIZE];
+	int expected_digest_len;
+};
+
+static void escape_mount_option_to(const char *str, char *dest)
+{
+	const char *s;
+	char *d;
+
+	d = dest + strlen(dest);
+	for (s = str; *s != 0; s++) {
+		if (*s == ',')
+			*d++ = '\\';
+		*d++ = *s;
+	}
+	*d++ = 0;
+}
+
+static char *escape_mount_option(const char *str)
+{
+	const char *s;
+	char *res;
+	int n_escapes = 0;
+
+	for (s = str; *s != 0; s++) {
+		if (*s == ',')
+			n_escapes++;
+	}
+
+	res = malloc(strlen(str) + n_escapes + 1);
+	if (res == NULL)
+		return NULL;
+
+	*res = 0;
+
+	escape_mount_option_to(str, res);
+
+	return res;
+}
+
+static int hexdigit(char c)
+{
+	if (c >= '0' && c <= '9')
+		return c - '0';
+	if (c >= 'a' && c <= 'f')
+		return 10 + (c - 'a');
+	if (c >= 'A' && c <= 'F')
+		return 10 + (c - 'A');
+	return -1;
+}
+
+static int digest_to_raw(const char *digest, uint8_t *raw, int max_size)
+{
+	int size = 0;
+
+	while (*digest) {
+		char c1, c2;
+		int n1, n2;
+
+		if (size >= max_size)
+			return -1;
+
+		c1 = *digest++;
+		n1 = hexdigit(c1);
+		if (n1 < 0)
+			return -1;
+
+		c2 = *digest++;
+		n2 = hexdigit(c2);
+		if (n2 < 0)
+			return -1;
+
+		raw[size++] = (n1 & 0xf) << 4 | (n2 & 0xf);
+	}
+
+	return size;
+}
+
+static int lcfs_validate_mount_options(struct lcfs_mount_state_s *state)
+{
+	struct lcfs_mount_options_s *options = state->options;
+
+	if ((options->flags & ~LCFS_MOUNT_FLAGS_MASK) != 0) {
+		return -EINVAL;
+	}
+
+	if (options->n_objdirs == 0)
+		return -EINVAL;
+
+	if ((options->upperdir && !options->workdir) ||
+	    (!options->upperdir && options->workdir))
+		return -EINVAL;
+
+	if (options->expected_digest) {
+		int raw_len = digest_to_raw(options->expected_digest,
+					    state->expected_digest, MAX_DIGEST_SIZE);
+		if (raw_len < 0)
+			return -EINVAL;
+		state->expected_digest_len = raw_len;
+	}
+
+	return 0;
+}
+
+static int lcfs_validate_verity_fd(struct lcfs_mount_state_s *state)
+{
+	struct {
+		struct fsverity_digest fsv;
+		char buf[MAX_DIGEST_SIZE];
+	} buf;
+	int res;
+
+	if (state->expected_digest_len == 0)
+		return 0;
+
+	buf.fsv.digest_size = MAX_DIGEST_SIZE;
+	res = ioctl(state->fd, FS_IOC_MEASURE_VERITY, &buf.fsv);
+	if (res == -1) {
+		if (errno == ENODATA || errno == EOPNOTSUPP || errno == ENOTTY)
+			return -ENOVERITY;
+		return -errno;
+	}
+	if (buf.fsv.digest_size != state->expected_digest_len ||
+	    memcmp(state->expected_digest, buf.fsv.digest, buf.fsv.digest_size) != 0)
+		return -EWRONGVERITY;
+
+	return 0;
+}
+
+static int setup_loopback(int fd, const char *image_path, char *loopname)
+{
+	struct loop_config loopconfig = { 0 };
+	int loopctlfd, loopfd;
+	long devnr;
+	int errsv;
+
+	loopctlfd = open("/dev/loop-control", O_RDWR);
+	if (loopctlfd < 0)
+		return -errno;
+
+	devnr = ioctl(loopctlfd, LOOP_CTL_GET_FREE);
+	errsv = errno;
+	close(loopctlfd);
+	if (devnr == -1) {
+		return -errsv;
+	}
+
+	sprintf(loopname, "/dev/loop%ld", devnr);
+	loopfd = open(loopname, O_RDWR);
+	if (loopfd < 0)
+		return -errno;
+
+	loopconfig.fd = fd;
+	loopconfig.block_size =
+		4096; /* This is what we use for the erofs block size, so probably good */
+	loopconfig.info.lo_flags =
+		LO_FLAGS_READ_ONLY | LO_FLAGS_DIRECT_IO | LO_FLAGS_AUTOCLEAR;
+	if (image_path)
+		strncat((char *)loopconfig.info.lo_file_name, image_path,
+			LO_NAME_SIZE - 1);
+
+	if (ioctl(loopfd, LOOP_CONFIGURE, &loopconfig) < 0) {
+		errsv = errno;
+		close(loopfd);
+		return -errsv;
+	}
+
+	return loopfd;
+}
+
+static char *compute_lower(const char *imagemount, struct lcfs_mount_state_s *state)
+{
+	size_t size;
+	char *lower;
+	int i;
+
+	/* Compute the total max size (including escapes) */
+	size = 2 * strlen(imagemount);
+	for (i = 0; i < state->options->n_objdirs; i++)
+		size += 1 + 2 * strlen(state->options->objdirs[i]);
+
+	lower = malloc(size + 1);
+	if (lower == NULL)
+		return NULL;
+	*lower = 0;
+
+	escape_mount_option_to(imagemount, lower);
+
+	for (i = 0; i < state->options->n_objdirs; i++) {
+		strcat(lower, ":");
+		escape_mount_option_to(state->options->objdirs[i], lower);
+	}
+
+	return lower;
+}
+
+static int lcfs_mount(struct lcfs_mount_state_s *state)
+{
+	struct lcfs_mount_options_s *options = state->options;
+	struct lcfs_erofs_header_s header;
+	uint32_t image_flags;
+	bool image_has_acls;
+	char imagemountbuf[] = "/tmp/.composefs.XXXXXX";
+	char *imagemount;
+	char loopname[PATH_MAX];
+	int res, errsv;
+	char *lowerdir = NULL;
+	char *upperdir = NULL;
+	char *workdir = NULL;
+	char *overlay_options = NULL;
+	int loopfd;
+	bool require_verity;
+	bool readonly;
+	int mount_flags;
+
+	res = lcfs_validate_verity_fd(state);
+	if (res < 0)
+		return res;
+
+	res = pread(state->fd, &header, sizeof(header), 0);
+	if (res < 0)
+		return -errno;
+
+	if (lcfs_u32_from_file(header.magic) != LCFS_EROFS_MAGIC)
+		return -EINVAL;
+
+	image_flags = lcfs_u32_from_file(header.flags);
+	image_has_acls = (image_flags & LCFS_EROFS_FLAGS_HAS_ACL) != 0;
+
+	require_verity = (options->flags & LCFS_MOUNT_FLAGS_REQUIRE_VERITY) != 0;
+	readonly = (options->flags & LCFS_MOUNT_FLAGS_READONLY) != 0;
+
+	loopfd = setup_loopback(state->fd, state->image_path, loopname);
+	if (loopfd < 0)
+		return loopfd;
+
+	imagemount = mkdtemp(imagemountbuf);
+	if (imagemount == NULL) {
+		errsv = errno;
+		close(loopfd);
+		return -errsv;
+	}
+
+	res = mount(loopname, imagemount, "erofs", MS_RDONLY,
+		    image_has_acls ? "" : "noacl");
+	errsv = errno;
+	close(loopfd);
+	if (res < 0) {
+		rmdir(imagemount);
+		return -errsv;
+	}
+
+	lowerdir = compute_lower(imagemount, state);
+	if (lowerdir == NULL) {
+		res = -ENOMEM;
+		goto fail;
+	}
+
+	if (options->upperdir)
+		upperdir = escape_mount_option(options->upperdir);
+	if (options->workdir)
+		workdir = escape_mount_option(options->workdir);
+
+	res = asprintf(&overlay_options,
+		       "metacopy=on,redirect_dir=on,lowerdir=%s%s%s%s%s%s", lowerdir,
+		       upperdir ? ",upperdir=" : "", upperdir ? upperdir : "",
+		       workdir ? ",workdir=" : "", workdir ? workdir : "",
+		       require_verity ? ",verity=require" : "");
+	if (res < 0) {
+		res = -ENOMEM;
+		goto fail;
+	}
+
+	mount_flags = 0;
+	if (readonly)
+		mount_flags |= MS_RDONLY;
+
+	res = mount("overlay", state->mountpoint, "overlay", mount_flags,
+		    overlay_options);
+
+fail:
+	free(lowerdir);
+	free(workdir);
+	free(upperdir);
+	free(overlay_options);
+
+	umount2(imagemount, MNT_DETACH);
+	rmdir(imagemount);
+
+	return res;
+}
+
+int lcfs_mount_fd(int fd, const char *mountpoint, struct lcfs_mount_options_s *options)
+{
+	struct lcfs_mount_state_s state = { .mountpoint = mountpoint,
+					    .options = options,
+					    .fd = fd };
+	int res;
+
+	res = lcfs_validate_mount_options(&state);
+	if (res < 0) {
+		errno = -res;
+		return -1;
+	}
+
+	res = lcfs_mount(&state);
+	if (res < 0) {
+		errno = -res;
+		return -1;
+	}
+	return 0;
+}
+
+int lcfs_mount_image(const char *path, const char *mountpoint,
+		     struct lcfs_mount_options_s *options)
+{
+	struct lcfs_mount_state_s state = { .image_path = path,
+					    .mountpoint = mountpoint,
+					    .options = options,
+					    .fd = -1 };
+	int fd, res;
+
+	res = lcfs_validate_mount_options(&state);
+	if (res < 0) {
+		errno = -res;
+		return -1;
+	}
+
+	fd = open(path, O_RDONLY);
+	if (fd < 0) {
+		return -1;
+	}
+	state.fd = fd;
+
+	res = lcfs_mount(&state);
+	close(fd);
+	if (res < 0) {
+		errno = -res;
+		return -1;
+	}
+
+	return 0;
+}

--- a/libcomposefs/lcfs-mount.h
+++ b/libcomposefs/lcfs-mount.h
@@ -1,0 +1,55 @@
+/* lcfs
+   Copyright (C) 2023 Alexander Larsson <alexl@redhat.com>
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _LCFS_OPS_H
+#define _LCFS_OPS_H
+
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#define ENOVERITY ENOTTY
+#define EWRONGVERITY EILSEQ
+
+enum lcfs_mount_flags_t {
+	LCFS_MOUNT_FLAGS_NONE = 0,
+	LCFS_MOUNT_FLAGS_REQUIRE_VERITY = (1 << 0),
+	LCFS_MOUNT_FLAGS_READONLY = (1 << 1),
+
+	LCFS_MOUNT_FLAGS_MASK = (1 << 2) - 1,
+};
+
+struct lcfs_mount_options_s {
+	const char **objdirs;
+	size_t n_objdirs;
+	const char *workdir;
+	const char *upperdir;
+	const char *expected_digest;
+	uint32_t flags;
+
+	uint32_t reserved[4];
+	void *reserved2[4];
+};
+
+int lcfs_mount_image(const char *path, const char *mountpoint,
+		     struct lcfs_mount_options_s *options);
+int lcfs_mount_fd(int fd, const char *mountpoint,
+		  struct lcfs_mount_options_s *options);
+
+#endif

--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -1927,7 +1927,7 @@ int lcfs_write_to(struct lcfs_node_s *root, struct lcfs_write_options_s *options
 	int res;
 
 	/* Check for unknown flags */
-	if ((options->flags & LCFS_FLAGS_MASK) != 0) {
+	if ((options->flags & ~LCFS_FLAGS_MASK) != 0) {
 		errno = -EINVAL;
 		return -1;
 	}

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -1,4 +1,5 @@
-bin_PROGRAMS = mkcomposefs mountcomposefs
+bin_PROGRAMS = mkcomposefs
+sbin_PROGRAMS = mount.composefs
 noinst_PROGRAMS = dump
 
 if USE_YAJL
@@ -13,8 +14,8 @@ dump_LDADD = ../libcomposefs/libcomposefs.la $(LIBCRYPTO_LIBS)
 mkcomposefs_SOURCES = mkcomposefs.c
 mkcomposefs_LDADD =  ../libcomposefs/libcomposefs.la $(LIBCRYPTO_LIBS) $(FSVERITY_LIBS)
 
-mountcomposefs_SOURCES = mountcomposefs.c
-mountcomposefs_LDADD = ../libcomposefs/libcomposefs.la $(LIBCRYPTO_LIBS)
+mount_composefs_SOURCES = mountcomposefs.c
+mount_composefs_LDADD = ../libcomposefs/libcomposefs.la $(LIBCRYPTO_LIBS)
 
 writer_json_SOURCES = writer-json.c read-file.c read-file.h
 writer_json_LDADD = ../libcomposefs/libcomposefs.la $(LIBS_YAJL) $(LIBCRYPTO_LIBS)

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -14,7 +14,7 @@ mkcomposefs_SOURCES = mkcomposefs.c
 mkcomposefs_LDADD =  ../libcomposefs/libcomposefs.la $(LIBCRYPTO_LIBS) $(FSVERITY_LIBS)
 
 mountcomposefs_SOURCES = mountcomposefs.c
-mountcomposefs_LDADD =
+mountcomposefs_LDADD = ../libcomposefs/libcomposefs.la $(LIBCRYPTO_LIBS)
 
 writer_json_SOURCES = writer-json.c read-file.c read-file.h
 writer_json_LDADD = ../libcomposefs/libcomposefs.la $(LIBS_YAJL) $(LIBCRYPTO_LIBS)

--- a/tools/mountcomposefs.c
+++ b/tools/mountcomposefs.c
@@ -35,8 +35,7 @@
 #include <linux/mount.h>
 #include <linux/fsverity.h>
 
-#include "libcomposefs/lcfs-erofs.h"
-#include "libcomposefs/lcfs.h"
+#include "libcomposefs/lcfs-mount.h"
 
 #define MAX_OBJDIR 10
 
@@ -51,11 +50,6 @@ static void printexit(const char *format, ...)
 	exit(1);
 }
 
-static void oom(void)
-{
-	printexit("Out of memory\n");
-}
-
 static void usage(const char *argv0)
 {
 	fprintf(stderr,
@@ -68,70 +62,6 @@ static void usage(const char *argv0)
 #define OPT_WORKDIR 102
 #define OPT_DIGEST 103
 #define OPT_REQUIRE_VERITY 104
-
-static char *escape_mount_option(const char *str)
-{
-	const char *s;
-	char *res, *d;
-	int n_escapes = 0;
-
-	for (s = str; *s != 0; s++) {
-		if (*s == ',')
-			n_escapes++;
-	}
-
-	res = malloc(strlen(str) + n_escapes + 1);
-	if (res == NULL)
-		oom();
-
-	d = res;
-	for (s = str; *s != 0; s++) {
-		if (*s == ',')
-			*d++ = '\\';
-		*d++ = *s;
-	}
-	*d++ = 0;
-
-	return res;
-}
-
-static int hexdigit(char c)
-{
-	if (c >= '0' && c <= '9')
-		return c - '0';
-	if (c >= 'a' && c <= 'f')
-		return 10 + (c - 'a');
-	if (c >= 'A' && c <= 'F')
-		return 10 + (c - 'A');
-	return -1;
-}
-
-static int digest_to_raw(const char *digest, uint8_t *raw, int max_size)
-{
-	int size = 0;
-
-	while (*digest) {
-		char c1, c2;
-		int n1, n2;
-
-		if (size >= max_size)
-			return -1;
-
-		c1 = *digest++;
-		n1 = hexdigit(c1);
-		if (n1 < 0)
-			return -1;
-
-		c2 = *digest++;
-		n2 = hexdigit(c2);
-		if (n2 < 0)
-			return -1;
-
-		raw[size++] = (n1 & 0xf) << 4 | (n2 & 0xf);
-	}
-
-	return size;
-}
 
 int main(int argc, char **argv)
 {
@@ -168,53 +98,35 @@ int main(int argc, char **argv)
 		},
 		{},
 	};
+	const char *objdirs[MAX_OBJDIR] = { NULL };
+	struct lcfs_mount_options_s options = { .objdirs = objdirs };
 	const char *bin = argv[0];
 	const char *image_path = NULL;
 	const char *mount_path = NULL;
-	const char *upperdir = NULL;
-	const char *workdir = NULL;
-	const char *digest = NULL;
-	char *escaped_upperdir = NULL;
-	char *escaped_workdir = NULL;
-	bool require_verity = false;
-	const char *objdirs[MAX_OBJDIR] = { NULL };
-	int n_objdirs = 0;
-	int opt;
-	int fd, loopctlfd, loopfd;
-	long devnr;
-	char imagemountbuf[] = "/tmp/composefs.XXXXXX";
-	char *imagemount;
-	char *escaped;
-	char loopname[PATH_MAX];
-	int res;
-	char *overlay_options;
-	char lower[PATH_MAX * (MAX_OBJDIR + 1)];
-	struct loop_config loopconfig = { 0 };
-	struct lcfs_erofs_header_s header;
-	uint32_t image_flags;
-	bool image_has_acls;
+	int opt, fd, res;
 
 	while ((opt = getopt_long(argc, argv, "", longopts, NULL)) != -1) {
 		switch (opt) {
 		case OPT_OBJDIR:
-			if (n_objdirs == MAX_OBJDIR) {
+			if (options.n_objdirs == MAX_OBJDIR) {
 				fprintf(stderr, "Too many object dirs\n");
 				exit(EXIT_FAILURE);
 			}
-			objdirs[n_objdirs++] = optarg;
+			options.objdirs[options.n_objdirs++] = optarg;
 			break;
 		case OPT_UPPERDIR:
-			upperdir = optarg;
+			options.upperdir = optarg;
 			break;
 		case OPT_WORKDIR:
-			workdir = optarg;
+			options.workdir = optarg;
 			break;
 		case OPT_DIGEST:
-			digest = optarg;
-			require_verity = true;
+			options.expected_digest = optarg;
+			options.flags |= LCFS_MOUNT_FLAGS_REQUIRE_VERITY;
 			break;
 		case OPT_REQUIRE_VERITY:
-			require_verity = true;
+			options.expected_digest = optarg;
+			options.flags |= LCFS_MOUNT_FLAGS_REQUIRE_VERITY;
 			break;
 		default:
 			usage(bin);
@@ -239,13 +151,14 @@ int main(int argc, char **argv)
 	}
 	mount_path = argv[1];
 
-	if (n_objdirs == 0) {
+	if (options.n_objdirs == 0) {
 		fprintf(stderr, "No object dirs specified\n");
 		usage(bin);
 		exit(1);
 	}
 
-	if ((upperdir && !workdir) || (!upperdir && workdir)) {
+	if ((options.upperdir && !options.workdir) ||
+	    (!options.upperdir && options.workdir)) {
 		printexit("Both workdir and upperdir must be specified if used\n");
 	}
 
@@ -253,111 +166,20 @@ int main(int argc, char **argv)
 	if (fd < 0)
 		printexit("Failed to open %s: %s\n", image_path, strerror(errno));
 
-	if (digest) {
-		struct {
-			struct fsverity_digest fsv;
-			char buf[64];
-		} buf;
-		uint8_t raw_digest[64] = { 0 };
-		int raw_len;
-
-		raw_len = digest_to_raw(digest, raw_digest, sizeof(raw_digest));
-		if (raw_len < 0)
-			printexit("Invalid digest specified\n");
-
-		buf.fsv.digest_size = 64;
-		res = ioctl(fd, FS_IOC_MEASURE_VERITY, &buf.fsv);
-		if (res == -1) {
-			if (errno == ENODATA)
-				printexit("Image file lacks fs-verity digest\n");
-			if (errno == ENOTTY || errno == EOPNOTSUPP)
-				printexit("Image file lacks fs-verity digest: Not supported\n");
-			printexit("Failed to get image fs-verity digest: %s\n",
-				  strerror(errno));
-		}
-
-		if (buf.fsv.digest_size != raw_len ||
-		    memcmp(raw_digest, buf.fsv.digest, buf.fsv.digest_size) != 0)
-			printexit("Wrong fs-verity digest on image\n");
-	}
-
-	res = pread(fd, &header, sizeof(header), 0);
-	if (res < 0)
-		printexit("Failed to load header from %s: %s\n", image_path,
-			  strerror(errno));
-	if (lcfs_u32_from_file(header.magic) != LCFS_EROFS_MAGIC)
-		printexit("Invalid file header in %s\n", image_path);
-	image_flags = lcfs_u32_from_file(header.flags);
-	image_has_acls = (image_flags & LCFS_EROFS_FLAGS_HAS_ACL) != 0;
-
-	loopctlfd = open("/dev/loop-control", O_RDWR);
-	if (loopctlfd == -1)
-		printexit("Failed to open /dev/loop-control: %s\n", strerror(errno));
-
-	devnr = ioctl(loopctlfd, LOOP_CTL_GET_FREE);
-	if (devnr == -1)
-		printexit("Failed to find free loop device: %s\n", strerror(errno));
-	close(loopctlfd);
-
-	sprintf(loopname, "/dev/loop%ld", devnr);
-	loopfd = open(loopname, O_RDWR);
-	if (loopfd == -1)
-		printexit("Failed to open %s: %s\n", loopname, strerror(errno));
-
-	loopconfig.fd = fd;
-	loopconfig.block_size =
-		4096; /* This is what we use for the erofs block size, so probably good */
-	loopconfig.info.lo_flags =
-		LO_FLAGS_READ_ONLY | LO_FLAGS_DIRECT_IO | LO_FLAGS_AUTOCLEAR;
-	strncat((char *)loopconfig.info.lo_file_name, image_path, LO_NAME_SIZE - 1);
-
-	if (ioctl(loopfd, LOOP_CONFIGURE, &loopconfig) == -1)
-		printexit("Failed to setup loop device: %s\n", strerror(errno));
-
-	imagemount = mkdtemp(imagemountbuf);
-	if (imagemount == NULL)
-		printexit("Failed to create erofs mountpoint: %s\n", strerror(errno));
-
-	res = mount(loopname, imagemount, "erofs", 0,
-		    image_has_acls ? "ro" : "ro,noacl");
-	if (res < 0)
-		printexit("Failed to mount erofs: %s\n", strerror(errno));
-
-	*lower = 0;
-	escaped = escape_mount_option(imagemount);
-	strncat(lower, escaped, sizeof(lower) - 1);
-	free(escaped);
-	for (int i = n_objdirs - 1; i >= 0; i--) {
-		strncat(lower, ":", sizeof(lower) - strlen(lower) - 1);
-		escaped = escape_mount_option(objdirs[i]);
-		strncat(lower, objdirs[i], sizeof(lower) - strlen(lower) - 1);
-		free(escaped);
-	}
-
-	if (upperdir)
-		escaped_upperdir = escape_mount_option(upperdir);
-	if (workdir)
-		escaped_workdir = escape_mount_option(workdir);
-
-	res = asprintf(&overlay_options,
-		       "metacopy=on,redirect_dir=on,lowerdir=%s%s%s%s%s%s",
-		       lower, upperdir ? ",upperdir=" : "",
-		       upperdir ? escaped_upperdir : "",
-		       workdir ? ",workdir=" : "", workdir ? escaped_workdir : "",
-		       require_verity ? ",verity=require" : "");
-	if (res < 0)
-		oom();
-
-	res = mount("overlay", mount_path, "overlay", 0, overlay_options);
+	res = lcfs_mount_fd(fd, mount_path, &options);
 	if (res < 0) {
 		int errsv = errno;
-		umount2(imagemount, MNT_DETACH);
-		rmdir(imagemount);
-		printexit("Failed to mount overlay: %s\n", strerror(errsv));
-	}
 
-	umount2(imagemount, MNT_DETACH);
-	rmdir(imagemount);
+		if (errsv == ENOVERITY)
+			printexit("Failed to mount composefs %s: Image has no fs-verity\n",
+				  image_path);
+		else if (errsv == EWRONGVERITY)
+			printexit("Failed to mount composefs %s: Image has wrong fs-verity\n",
+				  image_path);
+
+		printexit("Failed to mount composefs %s: %s\n", image_path,
+			  strerror(errno));
+	}
 
 	return 0;
 }


### PR DESCRIPTION
This moves the code to mount erofs+overlayfs images into the libcomposefs so that others can easily use it. It also changes mountcomposefs to /sbin/mount.composefs with a CLI that matches /bin/mount, which allows mount to use it as a helper, like so:

```
$ mount -t composefs -obasedir=objects simple.erofs mnt
```
