### PR TITLE
mount: Add support for validating fs-verity signatures on images.

### DIFF
--- a/libcomposefs/lcfs-mount.c
+++ b/libcomposefs/lcfs-mount.c
@@ -158,20 +158,55 @@ static int lcfs_validate_verity_fd(struct lcfs_mount_state_s *state)
 		char buf[MAX_DIGEST_SIZE];
 	} buf;
 	int res;
+	bool require_signature;
+	char sig_data[1];
+	struct fsverity_read_metadata_arg read_metadata = { 0 };
 
-	if (state->expected_digest_len == 0)
-		return 0;
+	require_signature =
+		(state->options->flags & LCFS_MOUNT_FLAGS_REQUIRE_SIGNATURE) != 0;
+	if (require_signature) {
+		/* First ensure fs-verity is enabled for the image,
+		 * the actual digest doesn't matter at this point. */
+		buf.fsv.digest_size = MAX_DIGEST_SIZE;
+		res = ioctl(state->fd, FS_IOC_MEASURE_VERITY, &buf.fsv);
+		if (res == -1) {
+			if (errno == ENODATA || errno == EOPNOTSUPP || errno == ENOTTY)
+				return -ENOVERITY;
+			return -errno;
+		}
 
-	buf.fsv.digest_size = MAX_DIGEST_SIZE;
-	res = ioctl(state->fd, FS_IOC_MEASURE_VERITY, &buf.fsv);
-	if (res == -1) {
-		if (errno == ENODATA || errno == EOPNOTSUPP || errno == ENOTTY)
-			return -ENOVERITY;
-		return -errno;
+		/* If the file has verity enabled, has a signature and
+		 * we were able to open it, then the kernel will have
+		 * verified it against the kernel keyring, making it
+		 * valid. So, we read just one byte of the signature,
+		 * to validate that a signature exist in the file */
+
+		read_metadata.metadata_type = FS_VERITY_METADATA_TYPE_SIGNATURE;
+		read_metadata.offset = 0;
+		read_metadata.length = sizeof(sig_data);
+		read_metadata.buf_ptr = (size_t)&sig_data;
+
+		res = ioctl(state->fd, FS_IOC_READ_VERITY_METADATA, &read_metadata);
+		if (res == -1) {
+			if (errno == ENODATA)
+				return -ENOSIGNATURE;
+			return -errno;
+		}
 	}
-	if (buf.fsv.digest_size != state->expected_digest_len ||
-	    memcmp(state->expected_digest, buf.fsv.digest, buf.fsv.digest_size) != 0)
-		return -EWRONGVERITY;
+
+	if (state->expected_digest_len != 0) {
+		buf.fsv.digest_size = MAX_DIGEST_SIZE;
+		res = ioctl(state->fd, FS_IOC_MEASURE_VERITY, &buf.fsv);
+		if (res == -1) {
+			if (errno == ENODATA || errno == EOPNOTSUPP || errno == ENOTTY)
+				return -ENOVERITY;
+			return -errno;
+		}
+		if (buf.fsv.digest_size != state->expected_digest_len ||
+		    memcmp(state->expected_digest, buf.fsv.digest,
+			   buf.fsv.digest_size) != 0)
+			return -EWRONGVERITY;
+	}
 
 	return 0;
 }

--- a/libcomposefs/lcfs-mount.h
+++ b/libcomposefs/lcfs-mount.h
@@ -26,13 +26,15 @@
 
 #define ENOVERITY ENOTTY
 #define EWRONGVERITY EILSEQ
+#define ENOSIGNATURE EBADMSG
 
 enum lcfs_mount_flags_t {
 	LCFS_MOUNT_FLAGS_NONE = 0,
 	LCFS_MOUNT_FLAGS_REQUIRE_VERITY = (1 << 0),
 	LCFS_MOUNT_FLAGS_READONLY = (1 << 1),
+	LCFS_MOUNT_FLAGS_REQUIRE_SIGNATURE = (1 << 2),
 
-	LCFS_MOUNT_FLAGS_MASK = (1 << 2) - 1,
+	LCFS_MOUNT_FLAGS_MASK = (1 << 3) - 1,
 };
 
 struct lcfs_mount_options_s {

--- a/tools/mountcomposefs.c
+++ b/tools/mountcomposefs.c
@@ -112,6 +112,7 @@ int main(int argc, char **argv)
 	const char *opt_upperdir = NULL;
 	const char *opt_workdir = NULL;
 	bool opt_verity = false;
+	bool opt_signed = false;
 	bool opt_ro = false;
 	int opt, fd, res;
 
@@ -161,6 +162,8 @@ int main(int argc, char **argv)
 			opt_digest = value;
 		} else if (strcmp("verity", key) == 0) {
 			opt_verity = true;
+		} else if (strcmp("signed", key) == 0) {
+			opt_signed = true;
 		} else if (strcmp("upperdir", key) == 0) {
 			if (value == NULL)
 				printexit("No value specified for upperdir option\n");
@@ -216,6 +219,8 @@ int main(int argc, char **argv)
 
 	if (opt_verity)
 		options.flags |= LCFS_MOUNT_FLAGS_REQUIRE_VERITY;
+	if (opt_signed)
+		options.flags |= LCFS_MOUNT_FLAGS_REQUIRE_SIGNATURE;
 	if (opt_ro)
 		options.flags |= LCFS_MOUNT_FLAGS_READONLY;
 
@@ -232,6 +237,9 @@ int main(int argc, char **argv)
 				  image_path);
 		else if (errsv == EWRONGVERITY)
 			printexit("Failed to mount composefs %s: Image has wrong fs-verity\n",
+				  image_path);
+		else if (errsv == ENOSIGNATURE)
+			printexit("Failed to mount composefs %s: Image was not signed\n",
 				  image_path);
 
 		printexit("Failed to mount composefs %s: %s\n", image_path,


### PR DESCRIPTION
This works by using the build-in fs-verity signatures and the kernel keyring. When you open any file that has fs-verity enabled with a signature the kernel verifies its signature against the keys in the kernel .fs-verity keyring. If the required key is not in the keychain then open will fail.

So, to work with this we just ensure that the file is open (i.e. we have an fd to it), it has fs-verity enabled, and there is a signature for the file. If this is all true we must have the valid key in the keyring.

To test this, do something like this:


Generate keys and sign image:
```
    openssl req -newkey rsa:4096 -nodes -keyout key.pem -x509 -out cert.pem
    fsverity sign image.composefs image.composefs.sig --key=key.pem --cert=cert.pem
```
Load the certificate into the fs-verity keyring:
```
    openssl x509 -in cert.pem -out cert.der -outform der
    keyctl padd asymmetric '' %keyring:.fs-verity < cert.der
```

Optionally, lock the keyring so that no more keys can be added:
```
    keyctl restrict_keyring %keyring:.fs-verity
```
Sign the image:
```
    fsverity enable image.composefs --signature=image.composefs.sig
```

Mount the image with the `signed` option:
```
    mount -t composefs -o basedir=objects,signed image.composefs mnt
```

This will only succeed if image.composefs is signed with a key, and the matching cert is loaded in the keyring.

Fixes: https://github.com/containers/composefs/issues/101