### PR TITLE
Drop libsfverity dependency

### DIFF
--- a/composefs.spec.in
+++ b/composefs.spec.in
@@ -7,7 +7,7 @@ License:        GPLv2+
 URL:            https://github.com/containers/composefs
 Source0:        https://github.com/containers/composefs/releases/download/%{version}/%{name}-%{version}.tar.xz
 
-BuildRequires:  gcc automake libtool openssl-devel fsverity-utils-devel yajl-devel
+BuildRequires:  gcc automake libtool openssl-devel yajl-devel
 Requires:       %{name}-libs = %{version}-%{release}
 
 %description

--- a/configure.ac
+++ b/configure.ac
@@ -36,8 +36,6 @@ AC_COMPILE_IFELSE(
 		 AC_DEFINE([HAVE_FSCONFIG_CMD_CREATE_LINUX_MOUNT_H], 1, [Define if FSCONFIG_CMD_CREATE is available in linux/mount.h])],
 	[AC_MSG_RESULT(no)])
 
-PKG_CHECK_MODULES(FSVERITY, libfsverity)
-
 PKG_CHECK_MODULES(LCFS_DEP_CRYPTO, libcrypto,[
       AC_DEFINE([HAVE_OPENSSL], 1, [Define if we have openssl])
       with_openssl=yes

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -6,13 +6,13 @@ if USE_YAJL
 noinst_PROGRAMS += writer-json
 endif
 
-AM_CFLAGS = $(WARN_CFLAGS) $(FSVERITY_CFLAGS) -I$(top_srcdir)/
+AM_CFLAGS = $(WARN_CFLAGS) -I$(top_srcdir)/
 
 dump_SOURCES = dump.c
 dump_LDADD = ../libcomposefs/libcomposefs.la $(LIBCRYPTO_LIBS)
 
 mkcomposefs_SOURCES = mkcomposefs.c
-mkcomposefs_LDADD =  ../libcomposefs/libcomposefs.la $(LIBCRYPTO_LIBS) $(FSVERITY_LIBS)
+mkcomposefs_LDADD =  ../libcomposefs/libcomposefs.la $(LIBCRYPTO_LIBS)
 
 mount_composefs_SOURCES = mountcomposefs.c
 mount_composefs_LDADD = ../libcomposefs/libcomposefs.la $(LIBCRYPTO_LIBS)


### PR DESCRIPTION
We don't currently use it other than to enable fs-verity, which really is just a single ioctl call. So, lets call that directly instead.