### PR TITLE
mount: Pass MS_SILENT on first pass trying to mount overlayfs

### DIFF
--- a/libcomposefs/lcfs-mount.c
+++ b/libcomposefs/lcfs-mount.c
@@ -559,6 +559,8 @@ retry:
 	mount_flags = 0;
 	if (readonly)
 		mount_flags |= MS_RDONLY;
+	if (lowerdir_alt == 0)
+		mount_flags |= MS_SILENT;
 
 	res = mount("overlay", state->mountpoint, "overlay", mount_flags,
 		    overlay_options);


### PR DESCRIPTION
We're probing if "::" works, so maybe this will produce less spew.