### PR TITLE
lib: Add option for specifying the mountpoint for the erofs image

### DIFF
--- a/libcomposefs/lcfs-mount.h
+++ b/libcomposefs/lcfs-mount.h
@@ -50,6 +50,7 @@ struct lcfs_mount_options_s {
 	const char *expected_digest;
 	uint32_t flags;
 	int idmap_fd; /* userns fd */
+	const char *image_mountdir; /* Temporary location to mount images if needed */
 
 	uint32_t reserved[4];
 	void *reserved2[4];


### PR DESCRIPTION
Otherwise the random tmpdir will be encoded in the mount options. We want to use this in ostree so we can find the deploy dir from the root (overlay) mount.