### PR TITLE
tree-wide: Use O_CLOEXEC

### DIFF
--- a/libcomposefs/lcfs-mount.c
+++ b/libcomposefs/lcfs-mount.c
@@ -309,7 +309,7 @@ static int setup_loopback(int fd, const char *image_path, char *loopname)
 	long devnr;
 	int errsv;
 
-	loopctlfd = open("/dev/loop-control", O_RDWR);
+	loopctlfd = open("/dev/loop-control", O_RDWR | O_CLOEXEC);
 	if (loopctlfd < 0)
 		return -errno;
 
@@ -321,7 +321,7 @@ static int setup_loopback(int fd, const char *image_path, char *loopname)
 	}
 
 	sprintf(loopname, "/dev/loop%ld", devnr);
-	loopfd = open(loopname, O_RDWR);
+	loopfd = open(loopname, O_RDWR | O_CLOEXEC);
 	if (loopfd < 0)
 		return -errno;
 
@@ -775,7 +775,7 @@ int lcfs_mount_image(const char *path, const char *mountpoint,
 		return -1;
 	}
 
-	fd = open(path, O_RDONLY);
+	fd = open(path, O_RDONLY | O_CLOEXEC);
 	if (fd < 0) {
 		return -1;
 	}

--- a/tools/composefs-from-json.c
+++ b/tools/composefs-from-json.c
@@ -690,7 +690,7 @@ int main(int argc, char **argv)
 	argc -= optind;
 
 	if (out != NULL) {
-		out_file = fopen(out, "w");
+		out_file = fopen(out, "we");
 		if (out_file == NULL)
 			error(EXIT_FAILURE, errno, "Failed to open output file");
 	} else {
@@ -707,7 +707,7 @@ int main(int argc, char **argv)
 		if (strcmp(argv[i], "-") == 0) {
 			input_files[i] = stdin;
 		} else {
-			input_files[i] = fopen(argv[i], "r");
+			input_files[i] = fopen(argv[i], "re");
 			if (input_files[i] == NULL)
 				error(EXIT_FAILURE, errno, "open `%s`", argv[i]);
 		}

--- a/tools/composefs-from-json.c
+++ b/tools/composefs-from-json.c
@@ -97,7 +97,7 @@ static void do_namespace_sandbox(void)
 	if (ret < 0)
 		return;
 
-	fd = open("/proc/self/setgroups", O_WRONLY);
+	fd = open("/proc/self/setgroups", O_WRONLY | O_CLOEXEC);
 	if (fd < 0)
 		error(EXIT_FAILURE, errno, "open /proc/self/setgroups");
 	ret = write(fd, "deny", 4);
@@ -105,7 +105,7 @@ static void do_namespace_sandbox(void)
 		error(EXIT_FAILURE, errno, "write to /proc/self/gid_map");
 	close(fd);
 
-	fd = open("/proc/self/gid_map", O_WRONLY);
+	fd = open("/proc/self/gid_map", O_WRONLY | O_CLOEXEC);
 	if (fd < 0)
 		error(EXIT_FAILURE, errno, "open /proc/self/gid_map");
 	ret = dprintf(fd, "0 %d 1\n", gid);
@@ -113,7 +113,7 @@ static void do_namespace_sandbox(void)
 		error(EXIT_FAILURE, errno, "write to /proc/self/gid_map");
 	close(fd);
 
-	fd = open("/proc/self/uid_map", O_WRONLY);
+	fd = open("/proc/self/uid_map", O_WRONLY | O_CLOEXEC);
 	if (fd < 0)
 		error(EXIT_FAILURE, errno, "open /proc/self/uid_map");
 	ret = dprintf(fd, "0 %d 1\n", uid);
@@ -134,7 +134,7 @@ static void do_namespace_sandbox(void)
 	if (ret < 0)
 		error(EXIT_FAILURE, errno, "mount tmpfs");
 
-	old_root = open("/", O_PATH | O_DIRECTORY);
+	old_root = open("/", O_PATH | O_DIRECTORY | O_CLOEXEC);
 	if (old_root < 0)
 		error(EXIT_FAILURE, errno, "open /");
 

--- a/tools/dump.c
+++ b/tools/dump.c
@@ -308,7 +308,7 @@ int main(int argc, char *argv[])
 		error(EXIT_FAILURE, 0, "invalid mode");
 	}
 
-	fd = open(argv[2], O_RDONLY);
+	fd = open(argv[2], O_RDONLY | O_CLOEXEC);
 	if (fd < 0)
 		error(EXIT_FAILURE, errno, "open %s", argv[1]);
 

--- a/tools/mkcomposefs.c
+++ b/tools/mkcomposefs.c
@@ -541,7 +541,7 @@ int main(int argc, char **argv)
 			error(EXIT_FAILURE, 0, "stdout is a tty.  Refusing to use it");
 		out_file = stdout;
 	} else {
-		out_file = fopen(out, "w");
+		out_file = fopen(out, "we");
 		if (out_file == NULL)
 			error(EXIT_FAILURE, errno, "failed to open output file");
 	}

--- a/tools/mountcomposefs.c
+++ b/tools/mountcomposefs.c
@@ -247,7 +247,7 @@ int main(int argc, char **argv)
 		options.idmap_fd = userns_fd;
 	}
 
-	fd = open(image_path, O_RDONLY);
+	fd = open(image_path, O_RDONLY | O_CLOEXEC);
 	if (fd < 0)
 		printexit("Failed to open %s: %s\n", image_path, strerror(errno));
 

--- a/tools/read-file.c
+++ b/tools/read-file.c
@@ -106,7 +106,7 @@ char *fread_file(FILE *stream, size_t *length)
 
 char *read_file(const char *path, size_t *length)
 {
-	FILE *f = fopen(path, "r");
+	FILE *f = fopen(path, "re");
 	char *buf;
 	int save_errno;
 


### PR DESCRIPTION
tree-wide: Use O_CLOEXEC

This is just a best practice.

---

tree-wide: Use fopen(..., "e")

This maps to `O_CLOEXEC`.

---

