### PR TITLE
Two minor buildsys patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.o
 *.lo
-Makefile
+/Makefile
+libcomposefs/Makefile
+tools/Makefile
 Makefile.in
 aclocal.m4
 autom4te.cache

--- a/hacking/clang-format/Makefile
+++ b/hacking/clang-format/Makefile
@@ -2,6 +2,6 @@ all:
 
 clang-format:
 	# do not format files that were copied into the source directory.
-	git ls-files ../../libcomposefs ../../tools ../../kernel | egrep "\\.[hc]" | grep -v "bitrotate\|hash\|xalloc-oversized\|erofs_fs" | xargs clang-format -style=file -i
+	git ls-files ../../libcomposefs ../../tools ../../kernel | grep -Ee "\\.[hc]" | grep -v "bitrotate\|hash\|xalloc-oversized\|erofs_fs" | xargs clang-format -style=file -i
 
 .PHONY: clang-format


### PR DESCRIPTION
gitignore: Only ignore automake-generated Makefiles

Otherwise `hacking/clang-format/Makefile` doesn't show up
in my searches.

Signed-off-by: Colin Walters <walters@verbum.org>

---

hacking: use `grep -E`

To avoid a deprecation warning from `egrep`.

Signed-off-by: Colin Walters <walters@verbum.org>

---

