### PR TITLE
Use `cleanup_free` more

### DIFF
--- a/libcomposefs/lcfs-mount.c
+++ b/libcomposefs/lcfs-mount.c
@@ -488,9 +488,9 @@ static int lcfs_mount_erofs_ovl(struct lcfs_mount_state_s *state,
 	int res, errsv;
 	int lowerdir_alt = 0;
 	char *lowerdir[2] = { NULL, NULL };
-	char *upperdir = NULL;
-	char *workdir = NULL;
-	char *overlay_options = NULL;
+	cleanup_free char *upperdir = NULL;
+	cleanup_free char *workdir = NULL;
+	cleanup_free char *overlay_options = NULL;
 	int loopfd;
 	bool require_verity;
 	bool disable_verity;
@@ -575,7 +575,6 @@ retry:
 	}
 
 	if (res == -EINVAL && lowerdir_alt == 0) {
-		free(overlay_options);
 		lowerdir_alt++;
 		goto retry;
 	}
@@ -583,9 +582,6 @@ retry:
 fail:
 	free(lowerdir[0]);
 	free(lowerdir[1]);
-	free(workdir);
-	free(upperdir);
-	free(overlay_options);
 
 	umount2(imagemount, MNT_DETACH);
 	if (created_tmpdir) {
@@ -609,12 +605,12 @@ static int lcfs_mount_cfs(struct lcfs_mount_state_s *state)
 	const char *imagemount;
 	int mount_flags;
 	int verity_check = 1;
-	char *basedir = NULL;
-	char *cfs_options = NULL;
-	char *overlay_options = NULL;
-	char *upperdir = NULL;
-	char *workdir = NULL;
-	char *cfsimg = NULL;
+	cleanup_free char *basedir = NULL;
+	cleanup_free char *cfs_options = NULL;
+	cleanup_free char *overlay_options = NULL;
+	cleanup_free char *upperdir = NULL;
+	cleanup_free char *workdir = NULL;
+	cleanup_free char *cfsimg = NULL;
 
 	require_verity = (options->flags & LCFS_MOUNT_FLAGS_REQUIRE_VERITY) != 0;
 	disable_verity = (options->flags & LCFS_MOUNT_FLAGS_DISABLE_VERITY) != 0;
@@ -703,12 +699,6 @@ fail:
 			rmdir(imagemount);
 		}
 	}
-	free(cfsimg);
-	free(basedir);
-	free(cfs_options);
-	free(overlay_options);
-	free(workdir);
-	free(upperdir);
 
 	return res;
 }

--- a/tools/dump.c
+++ b/tools/dump.c
@@ -20,6 +20,7 @@
 #include "config.h"
 
 #include "libcomposefs/lcfs-cfs.h"
+#include "libcomposefs/lcfs-utils.h"
 
 #include <assert.h>
 #include <stdio.h>
@@ -245,7 +246,8 @@ static uint64_t lookup(const uint8_t *inode_data, const uint8_t *vdata,
 		       uint64_t parent, const void *what)
 {
 	char *it;
-	char *dpath, *path;
+	char *dpath;
+	cleanup_free char *path = NULL;
 	uint64_t current;
 
 	if (strcmp(what, "/") == 0)
@@ -263,12 +265,10 @@ static uint64_t lookup(const uint8_t *inode_data, const uint8_t *vdata,
 		current = find_child(inode_data, vdata, current, it);
 		if (current == UINT64_MAX) {
 			errno = ENOENT;
-			free(path);
 			return current;
 		}
 	}
 
-	free(path);
 	return current;
 }
 

--- a/tools/mkcomposefs.c
+++ b/tools/mkcomposefs.c
@@ -20,6 +20,7 @@
 #include "config.h"
 
 #include "libcomposefs/lcfs-writer.h"
+#include "libcomposefs/lcfs-utils.h"
 
 #include <stdio.h>
 #include <linux/limits.h>
@@ -87,7 +88,7 @@ static int ensure_dir(const char *path, mode_t mode)
 
 static int mkdir_parents(const char *pathname, int mode)
 {
-	char *fn = NULL;
+	cleanup_free char *fn = NULL;
 	char *p;
 
 	fn = strdup(pathname);
@@ -109,7 +110,6 @@ static int mkdir_parents(const char *pathname, int mode)
 		*p = '\0';
 
 		if (ensure_dir(fn, mode) != 0) {
-			free(fn);
 			return -1;
 		}
 
@@ -118,7 +118,6 @@ static int mkdir_parents(const char *pathname, int mode)
 			p++;
 	} while (p);
 
-	free(fn);
 	return 0;
 }
 
@@ -165,13 +164,6 @@ static int copy_file_data(int sfd, int dfd)
 
 	return 0;
 }
-
-static inline void cleanup_freep(void *p)
-{
-	void **pp = (void **)p;
-	free(*pp);
-}
-#define cleanup_free __attribute__((cleanup(cleanup_freep)))
 
 static int join_paths(char **out, const char *path1, const char *path2)
 {


### PR DESCRIPTION
lcfs-mount: Use `cleanup_free`

On general principle of avoiding memory leaks and double frees
by having deallocation happen automatically.

---

tools: Use `cleanup_free`

On general principle of avoiding memory leaks and double frees
by having deallocation happen automatically.

---

