### PR TITLE
ci: Add integration testing, misc cleanup

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,8 +2,32 @@ name: Test
 
 on: [push, pull_request]
 
+permissions:
+  actions: read
+
 jobs:
-  build_job:
+  build:
+    runs-on: ubuntu-latest
+    name: "Build"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo ./hacking/installdeps.sh
+      - name: Configure
+        run: ./autogen.sh && ./configure --prefix=/usr --sysconfdir=/etc --libdir=/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH) CFLAGS='-Wall -Werror'
+      - name: Build
+        run: make -j $(nproc)
+      - name: Unit tests
+        run: make check
+      - name: Capture build
+        run: make install DESTDIR=$(pwd)/instroot && tar -C instroot -czf composefs.tar .
+      - name: Upload binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: composefs.tar
+          path: composefs.tar
+  build-unit-cross:
     runs-on: ubuntu-latest
     name: Build on ${{ matrix.arch }}
 
@@ -33,32 +57,39 @@ jobs:
 
           githubToken: ${{ github.token }}
 
-          install: |
-            apt-get update -y
-            apt-get install -y automake libtool autoconf autotools-dev git make gcc libyajl-dev libssl-dev libfsverity-dev pkg-config
-
-            find $(pwd) -name '.git' -exec bash -c 'git config --global --add safe.directory ${0%/.git}' {} \;
-
           run: |
+            apt-get update -y
+            ./hacking/installdeps.sh
             ./autogen.sh
             ./configure CFLAGS='-Wall -Werror'
             make -j $(nproc)
             make check
-
-  clang-formatter:
+  integration:
+    needs: build
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
+
     steps:
-    - name: checkout
-      uses: actions/checkout@v2
-
-    - name: install dependencies
-      run: |
-            sudo apt-get update -y
-            sudo apt-get install -y make clang-format
-
-    - name: check formatting
-      run: |
-            sudo docker build -t clang-format hacking/clang-format
-            sudo docker run --rm -w /src -v ${PWD}:/src clang-format
+      - name: Install erofs kmod
+        run: sudo apt install linux-modules-extra-$(uname -r)
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Download
+        uses: actions/download-artifact@v2
+        with:
+          name: composefs.tar
+      - run: sudo tar -C / -xvf composefs.tar
+      - name: Integration tests
+        run: sudo ./tests/integration.sh
+  clang-format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: install dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y make clang-format
+      - name: check formatting
+        run: |
+          sudo docker build -t clang-format hacking/clang-format
+          sudo docker run --rm -w /src -v ${PWD}:/src clang-format

--- a/hacking/installdeps.sh
+++ b/hacking/installdeps.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -xeuo pipefail
+export DEBIAN_FRONTEND=noninteractive
+apt-get install -y automake libtool autoconf autotools-dev git make gcc libyajl-dev libssl-dev libfsverity-dev pkg-config

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# A basic integration test for composefs; we capture /usr/bin
+# from the host environment into a cfs, then mount it and compare
+# the output of ls -lR (without hardlink counts).
+set -xeuo pipefail
+
+# ls -l but without hardlinks
+nonhardlink_ls() {
+    ls "$@" | sed -e 's,^\([^ ]*\)  *\([0-9][0-9]*\)\(.*\)$,\1\3,'
+}
+
+cfsroot=/composefs
+rm ${cfsroot}/tmp -rf
+mkdir -p ${cfsroot}/{objects,roots,tmp}
+
+cd ${cfsroot}/tmp
+testsrc=/usr/bin
+mkcomposefs --digest-store=${cfsroot}/objects ${testsrc} ${cfsroot}/roots/test.cfs
+
+mkdir -p mnt
+mount.composefs -o basedir=${cfsroot}/objects ${cfsroot}/roots/test.cfs mnt
+(cd ${testsrc} && nonhardlink_ls -lR .) > src-ls.txt
+(cd mnt && nonhardlink_ls -lR .) > mnt-ls.txt
+failed=
+if ! diff -u src-ls.txt mnt-ls.txt; then
+    failed=1
+fi
+umount mnt
+if test -n "${failed}"; then
+    exit 1
+fi


### PR DESCRIPTION
Right now we only have unit tests that run unprivileged.  Add a proper "integration test" (ok it's a lame shell script) that runs as root and creates and mounts a composefs and does some sanity checking.  (This could obviously be greatly extended, this is just to have a starting point)

While we have the patient open

- The only CI tests were doing *cross* builds; i.e. we were ignoring x86_64.  Add a non-cross build, and capture its result (as a tarball) for integration testing
- Add `hacking/installdeps.sh` which captures our build dependencies for Debian at least and can be reused by mutiple jobs
- Add `permissions: actions: read` because we don't want our actions to be able to mutate anything - this makes untrusted PRs much safer