### PR TITLE
mount: Use the new syntax for overlayfs datalower dirs

### DIFF
--- a/libcomposefs/lcfs-mount.c
+++ b/libcomposefs/lcfs-mount.c
@@ -364,7 +364,7 @@ static char *compute_lower(const char *imagemount,
 	escape_mount_option_to(imagemount, lower);
 
 	for (i = 0; i < state->options->n_objdirs; i++) {
-		if (with_datalower && i == 0)
+		if (with_datalower)
 			strcat(lower, "::");
 		else
 			strcat(lower, ":");


### PR DESCRIPTION
The final merged variant of datalowers uses double-colon for every datalower directory, not just the first. I.e:

 -o lower1:lower2::lowerdata1::lowerdata2.