### PR TITLE
gitignore: Add `Makefile-*.am.inc`

### DIFF
--- a/libcomposefs/.gitignore
+++ b/libcomposefs/.gitignore
@@ -1,2 +1,4 @@
 .libs
 libcomposefs.la
+# This is used by ostree today, see https://github.com/ostreedev/ostree/blob/c4591c2d285a890c0db3789f9d8e1d727aa174af/autogen.sh#L38
+Makefile-*.am.inc


### PR DESCRIPTION
ostree uses composefs as a git submodule today; this is what we do in libglnx too.