### PR TITLE
library: Be more explicit about what kind of signatures/digest we mean

### DIFF
--- a/libcomposefs/lcfs-mount.c
+++ b/libcomposefs/lcfs-mount.c
@@ -228,8 +228,8 @@ static int lcfs_validate_mount_options(struct lcfs_mount_state_s *state)
 	    (!options->upperdir && options->workdir))
 		return -EINVAL;
 
-	if (options->expected_digest) {
-		int raw_len = digest_to_raw(options->expected_digest,
+	if (options->expected_fsverity_digest) {
+		int raw_len = digest_to_raw(options->expected_fsverity_digest,
 					    state->expected_digest, MAX_DIGEST_SIZE);
 		if (raw_len < 0)
 			return -EINVAL;
@@ -254,8 +254,8 @@ static int lcfs_validate_verity_fd(struct lcfs_mount_state_s *state)
 	char sig_data[1];
 	struct fsverity_read_metadata_arg read_metadata = { 0 };
 
-	require_signature =
-		(state->options->flags & LCFS_MOUNT_FLAGS_REQUIRE_SIGNATURE) != 0;
+	require_signature = (state->options->flags &
+			     LCFS_MOUNT_FLAGS_REQUIRE_FSVERITY_SIGNATURE) != 0;
 	if (require_signature) {
 		/* First ensure fs-verity is enabled for the image,
 		 * the actual digest doesn't matter at this point. */

--- a/libcomposefs/lcfs-mount.h
+++ b/libcomposefs/lcfs-mount.h
@@ -35,7 +35,7 @@ enum lcfs_mount_flags_t {
 	LCFS_MOUNT_FLAGS_NONE = 0,
 	LCFS_MOUNT_FLAGS_REQUIRE_VERITY = (1 << 0),
 	LCFS_MOUNT_FLAGS_READONLY = (1 << 1),
-	LCFS_MOUNT_FLAGS_REQUIRE_SIGNATURE = (1 << 2),
+	LCFS_MOUNT_FLAGS_REQUIRE_FSVERITY_SIGNATURE = (1 << 2),
 	LCFS_MOUNT_FLAGS_IDMAP = (1 << 3),
 	LCFS_MOUNT_FLAGS_DISABLE_VERITY = (1 << 4),
 
@@ -47,7 +47,7 @@ struct lcfs_mount_options_s {
 	size_t n_objdirs;
 	const char *workdir;
 	const char *upperdir;
-	const char *expected_digest;
+	const char *expected_fsverity_digest;
 	uint32_t flags;
 	int idmap_fd; /* userns fd */
 	const char *image_mountdir; /* Temporary location to mount images if needed */

--- a/tools/mountcomposefs.c
+++ b/tools/mountcomposefs.c
@@ -229,7 +229,7 @@ int main(int argc, char **argv)
 	options.upperdir = opt_upperdir;
 	options.workdir = opt_workdir;
 
-	options.expected_digest = opt_digest;
+	options.expected_fsverity_digest = opt_digest;
 
 	if (opt_verity && opt_noverity) {
 		printexit("Incompatible options verity, noverity\n");
@@ -240,7 +240,7 @@ int main(int argc, char **argv)
 	if (opt_noverity)
 		options.flags |= LCFS_MOUNT_FLAGS_DISABLE_VERITY;
 	if (opt_signed)
-		options.flags |= LCFS_MOUNT_FLAGS_REQUIRE_SIGNATURE;
+		options.flags |= LCFS_MOUNT_FLAGS_REQUIRE_FSVERITY_SIGNATURE;
 	if (opt_ro)
 		options.flags |= LCFS_MOUNT_FLAGS_READONLY;
 


### PR DESCRIPTION
As discussed in #151, we may want to use other signatures than the fs-verity ones, and at some point other digests too. So, be more explicit in the naming that we refer to specifically fsverity digests and fsverity signatures.