### PR TITLE
mkcomposefs: Add --print-digest-only

### DIFF
--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -9,13 +9,16 @@ nonhardlink_ls() {
     ls "$@" | sed -e 's,^\([^ ]*\)  *\([0-9][0-9]*\)\(.*\)$,\1\3,'
 }
 
-cfsroot=/composefs
+cfsroot=${cfsroot:-/composefs}
 rm ${cfsroot}/tmp -rf
 mkdir -p ${cfsroot}/{objects,roots,tmp}
 
 cd ${cfsroot}/tmp
 testsrc=/usr/bin
-mkcomposefs --digest-store=${cfsroot}/objects ${testsrc} ${cfsroot}/roots/test.cfs
+mkcomposefs --print-digest --digest-store=${cfsroot}/objects ${testsrc} ${cfsroot}/roots/test.cfs | tee digest.txt
+prev_digest=$(cat digest.txt)
+new_digest=$(mkcomposefs --by-digest --print-digest-only ${testsrc})
+test "$prev_digest" = "$new_digest"
 
 mkdir -p mnt
 mount.composefs -o basedir=${cfsroot}/objects ${cfsroot}/roots/test.cfs mnt


### PR DESCRIPTION
In some cases, it's very useful to just see what the composefs digest of an input tree is, without actually writing an image.  One could do this externally by allocating a tempfile, but it's nicer for us to do internally.

Here we allocate an anonymous `O_TMPFILE` and hence none of the written data will ever persist to disk.