### PR TITLE
lcfs: Drop function to remove child

### DIFF
--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -772,28 +772,6 @@ static void lcfs_node_remove_child_node(struct lcfs_node_s *parent, int offset,
 	lcfs_node_unref(child);
 }
 
-int lcfs_node_remove_child(struct lcfs_node_s *parent, const char *name)
-{
-	size_t i;
-
-	if ((parent->inode.st_mode & S_IFMT) != S_IFDIR) {
-		errno = ENOTDIR;
-		return -1;
-	}
-
-	for (i = 0; i < parent->children_size; ++i) {
-		struct lcfs_node_s *child = parent->children[i];
-
-		if (child->name && strcmp(child->name, name) == 0) {
-			lcfs_node_remove_child_node(parent, i, child);
-			return 0;
-		}
-	}
-
-	errno = ENOENT;
-	return -1;
-}
-
 int lcfs_node_add_child(struct lcfs_node_s *parent, struct lcfs_node_s *child,
 			const char *name)
 {

--- a/libcomposefs/lcfs-writer.h
+++ b/libcomposefs/lcfs-writer.h
@@ -84,7 +84,6 @@ LCFS_EXTERN struct lcfs_node_s *lcfs_node_get_parent(struct lcfs_node_s *node);
 LCFS_EXTERN int lcfs_node_add_child(struct lcfs_node_s *parent,
 				    struct lcfs_node_s *child, /* Takes ownership on success */
 				    const char *name);
-LCFS_EXTERN int lcfs_node_remove_child(struct lcfs_node_s *parent, const char *name);
 LCFS_EXTERN const char *lcfs_node_get_name(struct lcfs_node_s *node);
 LCFS_EXTERN size_t lcfs_node_get_n_children(struct lcfs_node_s *node);
 LCFS_EXTERN struct lcfs_node_s *lcfs_node_get_child(struct lcfs_node_s *node,


### PR DESCRIPTION

In general our use case is really constructing an entire filesystem
tree in one shot from external data; we don't have a use case for
dynamic mutations, which is what this function does.

Signed-off-by: Colin Walters <walters@verbum.org>

---

