### PR TITLE
mount: Fix two memory leaks

### DIFF
--- a/libcomposefs/lcfs-mount.c
+++ b/libcomposefs/lcfs-mount.c
@@ -525,6 +525,7 @@ static int lcfs_mount_erofs_ovl(struct lcfs_mount_state_s *state,
 		workdir = escape_mount_option(options->workdir);
 
 retry:
+	free(steal_pointer(&overlay_options));
 	res = asprintf(&overlay_options,
 		       "metacopy=on,redirect_dir=on,lowerdir=%s%s%s%s%s%s",
 		       lowerdir[lowerdir_alt], upperdir ? ",upperdir=" : "",

--- a/tools/mountcomposefs.c
+++ b/tools/mountcomposefs.c
@@ -275,5 +275,7 @@ int main(int argc, char **argv)
 			  strerror(errno));
 	}
 
+	free(options.objdirs);
+
 	return 0;
 }


### PR DESCRIPTION
This ensures we get a clean `-fsanitize=address` run.