### PR TITLE
Drop support for ctime

### DIFF
--- a/libcomposefs/lcfs-internal.h
+++ b/libcomposefs/lcfs-internal.h
@@ -80,8 +80,6 @@ struct lcfs_inode_s {
 	uint64_t st_size; /* Size of file, only used for regular files */
 	int64_t st_mtim_sec;
 	uint32_t st_mtim_nsec;
-	int64_t st_ctim_sec;
-	uint32_t st_ctim_nsec;
 };
 
 struct lcfs_node_s {

--- a/libcomposefs/lcfs-writer-erofs.c
+++ b/libcomposefs/lcfs-writer-erofs.c
@@ -934,8 +934,6 @@ static int add_overlay_whiteouts(struct lcfs_node_s *root)
 		child->inode.st_gid = root->inode.st_gid;
 		child->inode.st_mtim_sec = root->inode.st_mtim_sec;
 		child->inode.st_mtim_nsec = root->inode.st_mtim_nsec;
-		child->inode.st_ctim_sec = root->inode.st_ctim_sec;
-		child->inode.st_ctim_nsec = root->inode.st_ctim_nsec;
 
 		/* Inherit selinux context from root dir */
 		if (selinux != NULL) {

--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -585,8 +585,6 @@ struct lcfs_node_s *lcfs_load_node_from_file(int dirfd, const char *fname,
 	if ((buildflags & LCFS_BUILD_USE_EPOCH) == 0) {
 		ret->inode.st_mtim_sec = sb.st_mtim.tv_sec;
 		ret->inode.st_mtim_nsec = sb.st_mtim.tv_nsec;
-		ret->inode.st_ctim_sec = sb.st_ctim.tv_sec;
-		ret->inode.st_ctim_nsec = sb.st_ctim.tv_nsec;
 	}
 
 	if ((buildflags & LCFS_BUILD_SKIP_XATTRS) == 0) {
@@ -713,18 +711,6 @@ void lcfs_node_get_mtime(struct lcfs_node_s *node, struct timespec *time)
 {
 	time->tv_sec = node->inode.st_mtim_sec;
 	time->tv_nsec = node->inode.st_mtim_nsec;
-}
-
-void lcfs_node_set_ctime(struct lcfs_node_s *node, struct timespec *time)
-{
-	node->inode.st_ctim_sec = time->tv_sec;
-	node->inode.st_ctim_nsec = time->tv_nsec;
-}
-
-void lcfs_node_get_ctime(struct lcfs_node_s *node, struct timespec *time)
-{
-	time->tv_sec = node->inode.st_ctim_sec;
-	time->tv_nsec = node->inode.st_ctim_nsec;
 }
 
 struct lcfs_node_s *lcfs_node_lookup_child(struct lcfs_node_s *node, const char *name)

--- a/libcomposefs/lcfs-writer.h
+++ b/libcomposefs/lcfs-writer.h
@@ -106,8 +106,6 @@ LCFS_EXTERN uint64_t lcfs_node_get_size(struct lcfs_node_s *node);
 LCFS_EXTERN void lcfs_node_set_size(struct lcfs_node_s *node, uint64_t size);
 LCFS_EXTERN void lcfs_node_set_mtime(struct lcfs_node_s *node, struct timespec *time);
 LCFS_EXTERN void lcfs_node_get_mtime(struct lcfs_node_s *node, struct timespec *time);
-LCFS_EXTERN void lcfs_node_set_ctime(struct lcfs_node_s *node, struct timespec *time);
-LCFS_EXTERN void lcfs_node_get_ctime(struct lcfs_node_s *node, struct timespec *time);
 
 LCFS_EXTERN const uint8_t *lcfs_node_get_fsverity_digest(struct lcfs_node_s *node);
 LCFS_EXTERN void lcfs_node_set_fsverity_digest(struct lcfs_node_s *node,

--- a/tools/composefs-from-json.c
+++ b/tools/composefs-from-json.c
@@ -482,13 +482,6 @@ static int fill_file(const char *typ, struct lcfs_node_s *root,
 		lcfs_node_set_mtime(node, &ts);
 	}
 
-	v = get_child(entry, "changetime", yajl_t_string);
-	if (v) {
-		struct timespec ts;
-		parse_time(YAJL_GET_STRING(v), &ts);
-		lcfs_node_set_ctime(node, &ts);
-	}
-
 	v = get_child(entry, "devMinor", yajl_t_number);
 	if (v)
 		min = YAJL_GET_INTEGER(v);


### PR DESCRIPTION
As discussed in https://github.com/containers/storage/pull/1646 there is no support in EROFS for ctime != mtime.  The current code does nothing with it.

Drop support for it in the API.