### PR TITLE
composefs-from-json: skip empty dir components

### DIFF
--- a/tools/composefs-from-json.c
+++ b/tools/composefs-from-json.c
@@ -566,6 +566,9 @@ static struct lcfs_node_s *get_or_add_node(const char *typ,
 	while ((it = strsep(&dpath, "/"))) {
 		struct lcfs_node_s *c;
 
+		if (it[0] == '\0')
+			continue;
+
 		c = lcfs_node_lookup_child(node, it);
 		if (c) {
 			node = c;


### PR DESCRIPTION
solves a problem where a path like "sys/" would cause to add a node with an empty name.