### PR TITLE
erofs: Escape overlayfs features

### DIFF
--- a/libcomposefs/lcfs-internal.h
+++ b/libcomposefs/lcfs-internal.h
@@ -148,6 +148,9 @@ char *maybe_join_path(const char *a, const char *b);
 struct lcfs_node_s *follow_links(struct lcfs_node_s *node);
 int node_get_dtype(struct lcfs_node_s *node);
 
+int lcfs_node_rename_xattr(struct lcfs_node_s *node, size_t index,
+			   const char *new_name);
+
 /* lcfs-writer-erofs.c */
 
 int lcfs_write_erofs_to(struct lcfs_ctx_s *ctx);

--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -1201,3 +1201,27 @@ int lcfs_node_set_xattr(struct lcfs_node_s *node, const char *name,
 
 	return 0;
 }
+
+/* This is an internal function.
+ * Be careful to not cause duplicates if new_name already exist */
+int lcfs_node_rename_xattr(struct lcfs_node_s *node, size_t index, const char *new_name)
+{
+	struct lcfs_xattr_s *xattr;
+	cleanup_free char *dup = NULL;
+
+	dup = strdup(new_name);
+	if (dup == NULL) {
+		errno = ENOMEM;
+		return -1;
+	}
+
+	if (index >= node->n_xattrs) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	xattr = &node->xattrs[index];
+	free(xattr->key);
+	xattr->key = steal_pointer(&dup);
+	return 0;
+}


### PR DESCRIPTION
This escapes overlayfs xattrs and whiteouts according to the support in this patch series:
  https://lore.kernel.org/linux-unionfs/cover.1692198910.git.alexl@redhat.com/

Note: We should probably wait with merging this until we have more feedback on the kernel list about it.

Fixes  https://github.com/containers/composefs/issues/172