### PR TITLE
A few smaller/more obvious fixes from running `clang-analyzer`

### DIFF
--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -188,8 +188,6 @@ int lcfs_compute_tree(struct lcfs_ctx_s *ctx, struct lcfs_node_s *root)
 	ctx->min_mtim_nsec = root->inode.st_mtim_nsec;
 	ctx->has_acl = false;
 
-	node = root;
-
 	for (node = root, index = 0; node != NULL; node = node->next, index++) {
 		if ((node->inode.st_mode & S_IFMT) != S_IFDIR &&
 		    node->children_size != 0) {

--- a/tools/mkcomposefs.c
+++ b/tools/mkcomposefs.c
@@ -569,7 +569,7 @@ int main(int argc, char **argv)
 		cleanup_free char *cwd_cleanup = NULL;
 		cleanup_free char *tmp_pathbuf = NULL;
 		cleanup_free char *absolute_prefix = NULL;
-		char *cwd = "";
+		const char *cwd = "";
 		int r;
 
 		if (dir_path[0] != '/') {
@@ -578,6 +578,7 @@ int main(int argc, char **argv)
 				error(EXIT_FAILURE, errno,
 				      "retrieve current working directory");
 		}
+		(void)cwd_cleanup; // This is just used for cleanup
 		r = join_paths(&tmp_pathbuf, cwd, dir_path);
 		if (r < 0)
 			error(EXIT_FAILURE, errno, "compute directory path");

--- a/tools/mkcomposefs.c
+++ b/tools/mkcomposefs.c
@@ -319,7 +319,7 @@ static int fill_payload(struct lcfs_node_s *node, const char *path, size_t len,
 		char target[PATH_MAX + 1];
 		ssize_t s = readlink(path, target, sizeof(target));
 		if (s < 0)
-			return ret;
+			return s;
 
 		target[s] = '\0';
 		ret = lcfs_node_set_payload(node, target);

--- a/tools/mkcomposefs.c
+++ b/tools/mkcomposefs.c
@@ -89,16 +89,13 @@ static int ensure_dir(const char *path, mode_t mode)
 
 static int mkdir_parents(const char *pathname, int mode)
 {
-	cleanup_free char *fn = NULL;
-	char *p;
-
-	fn = strdup(pathname);
+	cleanup_free char *fn = strdup(pathname);
 	if (fn == NULL) {
 		errno = ENOMEM;
 		return -1;
 	}
 
-	p = fn;
+	char *p = fn;
 	while (*p == '/')
 		p++;
 


### PR DESCRIPTION
writer: Drop dead assignment

Spotted by clang-analyzer.

---

mkcomposefs: Silence an unused variable warning

clang-analyzer complains about this.  While we're here, make
the variable `const`.

---

mkcomposefs: Switch to declare-and-initialize to silence clang-analyzer

clang-analyzer complains about a leak; I think it's wrong, but changing
things to atomically initialize the variables silences it.

---

mkcomposefs: Fix possibly garbage return in error path

Found by clang-analyzer.

(At this point, I have to say: I don't understand why in 2021 we
 created a new project in the C programming language...)

---

