### PR TITLE
Use `noreturn` attribute for `printexit`

### DIFF
--- a/tools/cfs-fuse.c
+++ b/tools/cfs-fuse.c
@@ -56,6 +56,7 @@ uint64_t erofs_build_time;
 uint32_t erofs_build_time_nsec;
 int basedir_fd;
 
+static void printexit(const char *format, ...) __attribute__((noreturn));
 static void printexit(const char *format, ...)
 {
 	va_list args;

--- a/tools/mountcomposefs.c
+++ b/tools/mountcomposefs.c
@@ -37,6 +37,7 @@
 
 #include "libcomposefs/lcfs-mount.h"
 
+static void printexit(const char *format, ...) __attribute__((noreturn));
 static void printexit(const char *format, ...)
 {
 	va_list args;


### PR DESCRIPTION
This tells the compiler and static analyzers that we exit; in this case clang-analyzer was warning about a possible `NULL` deref in `mountcomposefs.c` that wasn't reachable.

That said, this function is the same thing as `errx`, but we can fix that as a followup.