### PR TITLE
lib: include endian.h for lcfs-internal.h

### DIFF
--- a/libcomposefs/lcfs-internal.h
+++ b/libcomposefs/lcfs-internal.h
@@ -17,6 +17,8 @@
 #ifndef _LCFS_INTERNAL_H
 #define _LCFS_INTERNAL_H
 
+#include <endian.h>
+
 #include "lcfs-writer.h"
 #include "lcfs-fsverity.h"
 #include "hash.h"


### PR DESCRIPTION
required for htole16 and friends  

----

fixes a build with clang16 against musl:  

```
In file included from ../composefs/libcomposefs/lcfs-writer.c:21:
../composefs/libcomposefs/lcfs-internal.h:35:9: error: call to undeclared function 'htole16'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        return htole16(val);
```

this is because clang16 no longer permits using functions without a prototype first (implicit-decl)