### PR TITLE
Inline small files

### DIFF
--- a/libcomposefs/lcfs-internal.h
+++ b/libcomposefs/lcfs-internal.h
@@ -98,6 +98,8 @@ struct lcfs_node_s {
 	char *name;
 	char *payload; /* backing file or symlink target */
 
+	uint8_t *content;
+
 	struct lcfs_xattr_s *xattrs;
 	size_t n_xattrs;
 

--- a/libcomposefs/lcfs-internal.h
+++ b/libcomposefs/lcfs-internal.h
@@ -23,6 +23,12 @@
 #include "lcfs-fsverity.h"
 #include "hash.h"
 
+/* When using LCFS_BUILD_INLINE_SMALL in lcfs_load_node_from_file() inline files below this size
+ * We pick 64 which is the size of a sha256 digest that would otherwise be used as a redirect
+ * xattr, so the inlined file is smaller.
+ */
+#define LCFS_BUILD_INLINE_FILE_SIZE_LIMIT 64
+
 #define ALIGN_TO(_offset, _align_size)                                         \
 	(((_offset) + _align_size - 1) & ~(_align_size - 1))
 

--- a/libcomposefs/lcfs-utils.h
+++ b/libcomposefs/lcfs-utils.h
@@ -23,6 +23,7 @@
 #include <unistd.h>
 
 #define max(a, b) ((a > b) ? (a) : (b))
+#define min(a, b) (((a) < (b)) ? (a) : (b))
 
 static inline void _lcfs_reset_errno_(int *saved_errno)
 {

--- a/libcomposefs/lcfs-writer.h
+++ b/libcomposefs/lcfs-writer.h
@@ -34,6 +34,7 @@ enum {
 	LCFS_BUILD_USE_EPOCH = (1 << 1),
 	LCFS_BUILD_SKIP_DEVICES = (1 << 2),
 	LCFS_BUILD_COMPUTE_DIGEST = (1 << 3),
+	LCFS_BUILD_NO_INLINE = (1 << 4),
 };
 
 enum lcfs_format_t {

--- a/libcomposefs/lcfs-writer.h
+++ b/libcomposefs/lcfs-writer.h
@@ -78,6 +78,10 @@ LCFS_EXTERN const char *lcfs_node_get_xattr_name(struct lcfs_node_s *node,
 
 LCFS_EXTERN int lcfs_node_set_payload(struct lcfs_node_s *node, const char *payload);
 
+LCFS_EXTERN int lcfs_node_set_content(struct lcfs_node_s *node,
+				      const uint8_t *data, size_t data_size);
+LCFS_EXTERN const uint8_t *lcfs_node_get_content(struct lcfs_node_s *node);
+
 LCFS_EXTERN struct lcfs_node_s *lcfs_node_lookup_child(struct lcfs_node_s *node,
 						       const char *name);
 LCFS_EXTERN struct lcfs_node_s *lcfs_node_get_parent(struct lcfs_node_s *node);

--- a/tests/dumpdir
+++ b/tests/dumpdir
@@ -1,0 +1,47 @@
+#!/usr/bin/python3
+
+import os
+import sys
+import shlex
+import hashlib
+import stat
+import argparse
+
+def log_error(error):
+    print("Readdir error: " + error)
+
+def dumpfile(file, root):
+    rel = os.path.relpath(file, root)
+    s = os.lstat(file)
+    nlink = s.st_nlink;
+    if args.no_nlink:
+        nlink = 1
+    print(f"{shlex.quote(rel)} {s.st_mode} {nlink} {s.st_uid}:{s.st_gid} {s.st_rdev} {s.st_mtime_ns}",end="")
+    if stat.S_ISREG(s.st_mode):
+        digest = hashlib.sha256(open(file,'rb').read()).hexdigest()
+        print(f" {s.st_size} sha256:{digest}",end="")
+    elif stat.S_ISLNK(s.st_mode):
+        link = os.readlink(file)
+        print(f" ->{shlex.quote(link)}",end="")
+
+    for attr in sorted(os.listxattr(file, follow_symlinks=False)):
+        v = os.getxattr(file, attr, follow_symlinks=False)
+        print(f" {attr}={v}", end="")
+
+    print()
+
+
+
+def dumpdir(root):
+    dumpfile(root, root)
+    for parent, dirs, files in os.walk(root, topdown=True, onerror=log_error):
+        for file in sorted(dirs + files):
+            dumpfile(os.path.join(parent, file), root)
+
+argParser = argparse.ArgumentParser()
+argParser.add_argument("--no-nlink", action='store_true')
+argParser.add_argument('path')
+
+args = argParser.parse_args()
+
+dumpdir(args.path)

--- a/tools/mkcomposefs.c
+++ b/tools/mkcomposefs.c
@@ -323,7 +323,8 @@ static int fill_payload(struct lcfs_node_s *node, const char *path, size_t len,
 		ret = lcfs_node_set_payload(node, target);
 		if (ret < 0)
 			return ret;
-	} else if ((lcfs_node_get_mode(node) & S_IFMT) == S_IFREG) {
+	} else if ((lcfs_node_get_mode(node) & S_IFMT) == S_IFREG &&
+		   lcfs_node_get_content(node) == NULL) {
 		const uint8_t *digest = NULL;
 
 		if (by_digest)


### PR DESCRIPTION
Some files are smaller than the size needed for the redirect and the digest, lets allow storing these inline instead.