### PR TITLE
composefs-from-json: skip path component "."

### DIFF
--- a/tools/composefs-from-json.c
+++ b/tools/composefs-from-json.c
@@ -562,7 +562,7 @@ static struct lcfs_node_s *get_or_add_node(const char *typ,
 	while ((it = strsep(&dpath, "/"))) {
 		struct lcfs_node_s *c;
 
-		if (it[0] == '\0')
+		if (it[0] == '\0' || strcmp(it, ".") == 0)
 			continue;
 
 		c = lcfs_node_lookup_child(node, it);


### PR DESCRIPTION
skip the path component when it is a single dot, since it refers to the current directory.