### PR TITLE
Update for release 0.9.0

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,14 +1,27 @@
 SUBDIRS=libcomposefs tools tests
 
+CLEANFILES=
+
+MANPAGES=\
+	man/mount.composefs.md \
+	man/mkcomposefs.md
+
 EXTRA_DIST=\
 	composefs.pc.in \
 	composefs.spec.in \
-	composefs.spec
+	composefs.spec \
+	${MANPAGES}
 
 pkgconfig_DATA = composefs.pc
 
-man/%.1: man/%.md
-	pandoc $+ -s -t man > $@
+if ENABLE_MAN
 
-install-man: man/mount.composefs.1 man/mkcomposefs.1
-	install -m 644 -D --target-directory=$(DESTDIR)$(mandir)/man1 $^
+man/%.1: man/%.md
+	mkdir -p man
+	${PANDOC} $+ -s -t man > $@
+
+man1_MANS = $(MANPAGES:.md=.1)
+
+CLEANFILES += ${man1_MANS}
+
+endif

--- a/composefs.spec.in
+++ b/composefs.spec.in
@@ -7,7 +7,7 @@ License:        GPLv2+
 URL:            https://github.com/containers/composefs
 Source0:        https://github.com/containers/composefs/releases/download/%{version}/%{name}-%{version}.tar.xz
 
-BuildRequires:  gcc automake libtool openssl-devel yajl-devel
+BuildRequires:  gcc automake libtool openssl-devel yajl-devel pandoc fuse3-devel
 Requires:       %{name}-libs = %{version}-%{release}
 
 %description
@@ -31,8 +31,10 @@ Library files for %{name}.
 
 %build
 %configure \
-           --disable-static
-
+           --disable-static \
+           --enable-man \
+           --with-yajl \
+           --with-fuse
 %make_build
 
 %install
@@ -51,7 +53,9 @@ rm -rf %{buildroot}%{_libdir}/libcomposefs.la
 %license COPYING COPYING.LIB
 %doc README.md
 %{_bindir}/mkcomposefs
+%{_bindir}/composefs-info
 %{_sbindir}/mount.composefs
+%{_mandir}/man*/*.gz
 
 %changelog
 * Fri Apr 21 2023 Alexander Larsson <alexl@redhat.com>

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([composefs], [0.1.4], [giuseppe@scrivano.org])
+AC_INIT([composefs], [0.9.0], [giuseppe@scrivano.org])
 AC_CONFIG_SRCDIR([tools/mkcomposefs.c])
 AC_CONFIG_HEADERS([config.h])
 AC_SYS_LARGEFILE

--- a/configure.ac
+++ b/configure.ac
@@ -69,6 +69,24 @@ AC_DEFUN([CC_CHECK_FLAGS_APPEND], [
   done
 ])
 
+AC_ARG_ENABLE(man,
+              [AS_HELP_STRING([--enable-man],
+                              [generate man pages [default=auto]])],,
+              enable_man=maybe)
+
+AS_IF([test "$enable_man" != no], [
+  AC_PATH_PROG([PANDOC], [pandoc])
+  AS_IF([test -z "$PANDOC"], [
+    AS_IF([test "$enable_man" = yes], [
+      AC_MSG_ERROR([pandoc is required for --enable-man])
+    ])
+    enable_man=no
+  ],[
+    enable_man=yes
+  ])
+])
+AM_CONDITIONAL(ENABLE_MAN, test "$enable_man" != no)
+
 ##################################################
 # Visibility handling
 ##################################################

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -9,7 +9,15 @@ if ENABLE_VALGRIND
 VALGRIND_PREFIX=libtool --mode=execute ${VALGRIND} --quiet --leak-check=yes --error-exitcode=42
 endif
 
-EXTRA_DIST = test-checksums.sh $(patsubst %,assets/%,${TEST_ASSETS_SMALL}) $(patsubst %,assets/%.sha256_erofs,${TEST_ASSETS_SMALL})
+EXTRA_DIST = \
+	gendir \
+	dumpdir \
+	test-lib.sh \
+	test-units.sh \
+	test-random-fuse.sh \
+	test-checksums.sh \
+	integration.sh \
+	$(patsubst %,assets/%,${TEST_ASSETS_SMALL}) $(patsubst %,assets/%.sha256_erofs,${TEST_ASSETS_SMALL})
 
 check-checksums:
 	VALGRIND_PREFIX="${VALGRIND_PREFIX}" $(srcdir)/test-checksums.sh "$(builddir)/../tools/" "$(srcdir)/assets" "${TEST_ASSETS}"

--- a/tests/test-checksums.sh
+++ b/tests/test-checksums.sh
@@ -4,7 +4,7 @@ BINDIR="$1"
 ASSET_DIR="$2"
 TEST_ASSETS="$3"
 
-. test-lib.sh
+. $(dirname $0)/test-lib.sh
 
 has_fsck=$(check_erofs_fsck)
 

--- a/tests/test-random-fuse.sh
+++ b/tests/test-random-fuse.sh
@@ -12,7 +12,7 @@ exit_cleanup() {
 
 trap exit_cleanup EXIT
 
-. test-lib.sh
+. $(dirname $0)/test-lib.sh
 
 GENDIRARGS=""
 if [ ${can_whiteout} == "n" ]; then
@@ -25,8 +25,8 @@ fi
 
 test_random() {
     echo Generating root dir
-    ./gendir $GENDIRARGS $workdir/root
-    ./dumpdir --userxattr --whiteout $workdir/root >  $workdir/root.dump
+    $(dirname $0)/gendir $GENDIRARGS $workdir/root
+    $(dirname $0)/dumpdir --userxattr --whiteout $workdir/root >  $workdir/root.dump
     echo Generating composefs image
     ${VALGRIND_PREFIX} ${BINDIR}/mkcomposefs --digest-store=$workdir/objects $workdir/root $workdir/root.cfs
     if [ $has_fsck == y ]; then
@@ -49,7 +49,7 @@ test_random() {
     mkdir -p $workdir/mnt
     echo Mounting composefs image using fuse
     ${BINDIR}/composefs-fuse -o source=$workdir/root.cfs,basedir=$workdir/objects $workdir/mnt
-    ./dumpdir --userxattr --whiteout $workdir/mnt >  $workdir/fuse.dump
+    $(dirname $0)/dumpdir --userxattr --whiteout $workdir/mnt >  $workdir/fuse.dump
 
     ${VALGRIND_PREFIX} ${BINDIR}/mkcomposefs --digest-store=$workdir/objects $workdir/mnt $workdir/fuse.cfs
     if [ $has_fsck == y ]; then
@@ -65,7 +65,7 @@ test_random() {
     fi
 
     ${BINDIR}/composefs-fuse -o source=$workdir/fuse.cfs,basedir=$workdir/objects $workdir/mnt
-    ./dumpdir --userxattr --whiteout $workdir/mnt >  $workdir/fuse2.dump
+    $(dirname $0)/dumpdir --userxattr --whiteout $workdir/mnt >  $workdir/fuse2.dump
     umount $workdir/mnt
 
     # fuse.cfs and fuse2.cfs files differ due to whiteout conversions and non-user xattrs.

--- a/tests/test-units.sh
+++ b/tests/test-units.sh
@@ -7,7 +7,7 @@ set -e
 workdir=$(mktemp -d /var/tmp/lcfs-test.XXXXXX)
 trap 'rm -rf -- "$workdir"' EXIT
 
-. test-lib.sh
+. $(dirname $0)/test-lib.sh
 
 function makeimage () {
     local dir=$1

--- a/tools/composefs-info.c
+++ b/tools/composefs-info.c
@@ -107,8 +107,11 @@ static void print_node(struct lcfs_node_s *node, char *parent_path)
 	for (size_t i = 0; i < lcfs_node_get_n_children(node); i++) {
 		struct lcfs_node_s *child = lcfs_node_get_child(node, i);
 		cleanup_free char *path = NULL;
+		int r;
 
-		asprintf(&path, "%s/%s", parent_path, lcfs_node_get_name(child));
+		r = asprintf(&path, "%s/%s", parent_path, lcfs_node_get_name(child));
+		if (r < 0)
+			oom();
 
 		uint32_t mode = lcfs_node_get_mode(child);
 		uint32_t type = mode & S_IFMT;
@@ -198,8 +201,11 @@ static void dump_node(struct lcfs_node_s *node, char *path)
 	for (size_t i = 0; i < lcfs_node_get_n_children(node); i++) {
 		struct lcfs_node_s *child = lcfs_node_get_child(node, i);
 		cleanup_free char *child_path = NULL;
+		int r;
 
-		asprintf(&child_path, "%s/%s", path, lcfs_node_get_name(child));
+		r = asprintf(&child_path, "%s/%s", path, lcfs_node_get_name(child));
+		if (r < 0)
+			oom();
 
 		dump_node(child, child_path);
 	}


### PR DESCRIPTION
    Bump version to 0.9.0
    
    This is the first stable release of composefs. Starting now, we
    guarantee a stable library ABI and a binary stable file format. The
    later means that any image build from an identical lcfs_node tree and
    identical write options, will produce a file that is binary identical
    to a later run even with a different version. The same is true for
    an mkcomposefs run with the same options.
    
    Major changes since 0.1.4:
    
    * All required overlayfs xattr changes are now upstream and the
      corresponding image generation changes have been made in
      composefs. This includes support for escaping overlayfs xattrs and
      whiteouts for nested overlayfs mounts.
    
    * fs-verity built-in signature support was dropped in favour of
      userspace signatures.
    
    * The erofs iamges now uses the new bloom filter for faster xattr
       lookups. This is backward compatible and old erofs version still
       work (sans the speedup).
    
    * Files can now be inlined in the erofs image to avoid overhead of
      using redirections for small files.
    
    * There is a new API to regenerate a lcfs_node tree from a composefs
      image file.
    
    * There is a new composefs-info tool that lets you dump info about
      images, including what objects it refers to and which ones are
      missing from a given basedir.
    
    * Various fixes, cleanups and new tests
