### PR TITLE
Fix compiler error

### DIFF
--- a/libcomposefs/lcfs-internal.h
+++ b/libcomposefs/lcfs-internal.h
@@ -62,37 +62,43 @@
 
 #define lcfs_u16_to_file(v)                                                    \
 	({                                                                     \
-		_Static_assert(sizeof(v) == sizeof(uint16_t));                 \
+		_Static_assert(sizeof(v) == sizeof(uint16_t),                  \
+			       "Size of v is not equal to size of uint16_t");  \
 		htole16(v);                                                    \
 	})
 
 #define lcfs_u32_to_file(v)                                                    \
 	({                                                                     \
-		_Static_assert(sizeof(v) == sizeof(uint32_t));                 \
+		_Static_assert(sizeof(v) == sizeof(uint32_t),                  \
+			       "Size of v is not equal to size of uint32_t");  \
 		htole32(v);                                                    \
 	})
 
 #define lcfs_u64_to_file(v)                                                    \
 	({                                                                     \
-		_Static_assert(sizeof(v) == sizeof(uint64_t));                 \
+		_Static_assert(sizeof(v) == sizeof(uint64_t),                  \
+			       "Size of v is not equal to size of uint64_t");  \
 		htole64(v);                                                    \
 	})
 
 #define lcfs_u16_from_file(v)                                                  \
 	({                                                                     \
-		_Static_assert(sizeof(v) == sizeof(uint16_t));                 \
+		_Static_assert(sizeof(v) == sizeof(uint16_t),                  \
+			       "Size of v is not equal to size of uint16_t");  \
 		le16toh(v);                                                    \
 	})
 
 #define lcfs_u32_from_file(v)                                                  \
 	({                                                                     \
-		_Static_assert(sizeof(v) == sizeof(uint32_t));                 \
+		_Static_assert(sizeof(v) == sizeof(uint32_t),                  \
+			       "Size of v is not equal to size of uint32_t");  \
 		le32toh(v);                                                    \
 	})
 
 #define lcfs_u64_from_file(v)                                                  \
 	({                                                                     \
-		_Static_assert(sizeof(v) == sizeof(uint64_t));                 \
+		_Static_assert(sizeof(v) == sizeof(uint64_t),                  \
+			       "Size of v is not equal to size of uint64_t");  \
 		le64toh(v);                                                    \
 	})
 


### PR DESCRIPTION
Compiler reported errors as:

  ./lcfs-internal.h:65:47: error: expected ‘,’ before ‘)’ token
     _Static_assert(sizeof(v) == sizeof(uint16_t));                 \
                                                 ^
  ./lcfs-internal.h:71:47: error: expected ‘,’ before ‘)’ token
     _Static_assert(sizeof(v) == sizeof(uint32_t));                 \
                                                 ^
  ./lcfs-internal.h:77:47: error: expected ‘,’ before ‘)’ token
     _Static_assert(sizeof(v) == sizeof(uint64_t));                 \
                                                 ^
  ./lcfs-internal.h:83:47: error: expected ‘,’ before ‘)’ token
     _Static_assert(sizeof(v) == sizeof(uint16_t));                 \
                                                 ^
  ./lcfs-internal.h:95:47: error: expected ‘,’ before ‘)’ token
     _Static_assert(sizeof(v) == sizeof(uint64_t));                 \
                                                 ^

Fix it by adding error messages.