### PR TITLE
read-file.c: restore errno after successful fclose()

### DIFF
--- a/tools/read-file.c
+++ b/tools/read-file.c
@@ -123,10 +123,9 @@ char *read_file(const char *path, size_t *length)
 		if (buf) {
 			save_errno = errno;
 			free(buf);
+			buf = NULL;
 		}
-		errno = save_errno;
-		return NULL;
 	}
-
+	errno = save_errno;
 	return buf;
 }


### PR DESCRIPTION
Revert any change to `errno` from a successful `fclose()`. According to [errno(3)](https://man7.org/linux/man-pages/man3/errno.3.html) a function that succeeds is allowed to change errno.



So it should be enough to
```diff
diff --git a/tools/read-file.c b/tools/read-file.c
index ee35a93..9d98663 100644
--- a/tools/read-file.c
+++ b/tools/read-file.c
@@ -118,15 +118,15 @@ char *read_file(const char *path, size_t *length)
        buf = fread_file(f, length);
 
        save_errno = errno;
 
        if (fclose(f) != 0) {
                if (buf) {
                        save_errno = errno;
                        free(buf);
                }
                errno = save_errno;
                return NULL;
        }
-
+       errno = save_errno
        return buf;
 }
```

I rearranged that code somewhat.

Does this PR make sense? (I'm not 100% sure)