### PR TITLE
Switch to new mount api for ovl on kernel 6.5 to fix escaping

### DIFF
--- a/libcomposefs/lcfs-mount.c
+++ b/libcomposefs/lcfs-mount.c
@@ -334,6 +334,75 @@ static char *compute_lower(const char *imagemount,
 	return lower;
 }
 
+static int lcfs_mount_ovl_legacy(struct lcfs_mount_state_s *state, char *imagemount)
+{
+	struct lcfs_mount_options_s *options = state->options;
+
+	bool require_verity =
+		(options->flags & LCFS_MOUNT_FLAGS_REQUIRE_VERITY) != 0;
+	bool readonly = (options->flags & LCFS_MOUNT_FLAGS_READONLY) != 0;
+
+	/* First try new version with :: separating datadirs. */
+	cleanup_free char *lowerdir_1 = compute_lower(imagemount, state, true);
+	if (lowerdir_1 == NULL) {
+		return -ENOMEM;
+	}
+	/* Can point to lowerdir_1 or _2 */
+	const char *lowerdir_target = lowerdir_1;
+
+	/* Then fall back. */
+	cleanup_free char *lowerdir_2 = compute_lower(imagemount, state, false);
+	if (lowerdir_2 == NULL) {
+		return -ENOMEM;
+	}
+
+	cleanup_free char *upperdir = NULL;
+	if (options->upperdir) {
+		upperdir = escape_mount_option(options->upperdir);
+		if (upperdir == NULL) {
+			return -ENOMEM;
+		}
+	}
+	cleanup_free char *workdir = NULL;
+	if (options->workdir) {
+		workdir = escape_mount_option(options->workdir);
+		if (workdir == NULL)
+			return -ENOMEM;
+	}
+
+	int res;
+	cleanup_free char *overlay_options = NULL;
+retry:
+	free(steal_pointer(&overlay_options));
+	res = asprintf(&overlay_options,
+		       "metacopy=on,redirect_dir=on,lowerdir=%s%s%s%s%s%s",
+		       lowerdir_target, upperdir ? ",upperdir=" : "",
+		       upperdir ? upperdir : "", workdir ? ",workdir=" : "",
+		       workdir ? workdir : "",
+		       require_verity ? ",verity=require" : "");
+	if (res < 0)
+		return -ENOMEM;
+
+	int mount_flags = 0;
+	if (readonly)
+		mount_flags |= MS_RDONLY;
+	if (lowerdir_target == lowerdir_1)
+		mount_flags |= MS_SILENT;
+
+	res = mount("overlay", state->mountpoint, "overlay", mount_flags,
+		    overlay_options);
+	if (res != 0) {
+		res = -errno;
+	}
+
+	if (res == -EINVAL && lowerdir_target == lowerdir_1) {
+		lowerdir_target = lowerdir_2;
+		goto retry;
+	}
+
+	return res;
+}
+
 static int lcfs_mount_erofs(const char *source, const char *target,
 			    uint32_t image_flags, struct lcfs_mount_state_s *state)
 {
@@ -421,22 +490,9 @@ static int lcfs_mount_erofs_ovl(struct lcfs_mount_state_s *state,
 	bool created_tmpdir = false;
 	char loopname[PATH_MAX];
 	int res, errsv;
-	cleanup_free char *lowerdir_1 = NULL;
-	cleanup_free char *lowerdir_2 = NULL;
-	cleanup_free char *upperdir = NULL;
-	cleanup_free char *workdir = NULL;
-	cleanup_free char *overlay_options = NULL;
-	/* Can point to lowerdir_1 or _2 */
-	const char *lowerdir_target = NULL;
 	int loopfd;
-	bool require_verity;
-	bool readonly;
-	int mount_flags;
 
 	image_flags = lcfs_u32_from_file(header->flags);
-
-	require_verity = (options->flags & LCFS_MOUNT_FLAGS_REQUIRE_VERITY) != 0;
-	readonly = (options->flags & LCFS_MOUNT_FLAGS_READONLY) != 0;
 
 	loopfd = setup_loopback(state->fd, state->image_path, loopname);
 	if (loopfd < 0)
@@ -464,68 +520,8 @@ static int lcfs_mount_erofs_ovl(struct lcfs_mount_state_s *state,
 	/* We use the legacy API to mount overlayfs, because the new API doesn't allow use
 	 * to pass in escaped directory names
 	 */
+	res = lcfs_mount_ovl_legacy(state, imagemount);
 
-	/* First try new version with :: separating datadirs. */
-	lowerdir_1 = compute_lower(imagemount, state, true);
-	if (lowerdir_1 == NULL) {
-		res = -ENOMEM;
-		goto fail;
-	}
-	lowerdir_target = lowerdir_1;
-
-	/* Then fall back. */
-	lowerdir_2 = compute_lower(imagemount, state, false);
-	if (lowerdir_2 == NULL) {
-		res = -ENOMEM;
-		goto fail;
-	}
-
-	if (options->upperdir) {
-		upperdir = escape_mount_option(options->upperdir);
-		if (upperdir == NULL) {
-			res = -ENOMEM;
-			goto fail;
-		}
-	}
-	if (options->workdir) {
-		workdir = escape_mount_option(options->workdir);
-		if (workdir == NULL) {
-			res = -ENOMEM;
-			goto fail;
-		}
-	}
-
-retry:
-	free(steal_pointer(&overlay_options));
-	res = asprintf(&overlay_options,
-		       "metacopy=on,redirect_dir=on,lowerdir=%s%s%s%s%s%s",
-		       lowerdir_target, upperdir ? ",upperdir=" : "",
-		       upperdir ? upperdir : "", workdir ? ",workdir=" : "",
-		       workdir ? workdir : "",
-		       require_verity ? ",verity=require" : "");
-	if (res < 0) {
-		res = -ENOMEM;
-		goto fail;
-	}
-
-	mount_flags = 0;
-	if (readonly)
-		mount_flags |= MS_RDONLY;
-	if (lowerdir_target == lowerdir_1)
-		mount_flags |= MS_SILENT;
-
-	res = mount("overlay", state->mountpoint, "overlay", mount_flags,
-		    overlay_options);
-	if (res != 0) {
-		res = -errno;
-	}
-
-	if (res == -EINVAL && lowerdir_target == lowerdir_1) {
-		lowerdir_target = lowerdir_2;
-		goto retry;
-	}
-
-fail:
 	umount2(imagemount, MNT_DETACH);
 	if (created_tmpdir) {
 		rmdir(imagemount);


### PR DESCRIPTION
This is required on kernel >= 6.5 to handle escaped commas in upper or lowerdirs due to an overlayfs change in escape handling behaviour  caused by the switch to the new mount api internally.
    
For anything post 6.5 we fallback to the old legacy implementation which supports escaping.

This fixes https://github.com/containers/composefs/issues/213