### PR TITLE
composefs-from-json; Include readv/writev in seccomp list

### DIFF
--- a/tools/composefs-from-json.c
+++ b/tools/composefs-from-json.c
@@ -56,8 +56,8 @@ static void do_seccomp_sandbox(void)
 		SCMP_SYS(brk),	      SCMP_SYS(close),	SCMP_SYS(exit),
 		SCMP_SYS(exit_group), SCMP_SYS(fstat),	SCMP_SYS(lseek),
 		SCMP_SYS(mmap),	      SCMP_SYS(mremap), SCMP_SYS(munmap),
-		SCMP_SYS(newfstatat), SCMP_SYS(read),	SCMP_SYS(sysinfo),
-		SCMP_SYS(write),
+		SCMP_SYS(newfstatat), SCMP_SYS(read),	SCMP_SYS(readv),
+		SCMP_SYS(sysinfo),    SCMP_SYS(write),	SCMP_SYS(writev),
 	};
 
 	ctx = seccomp_init(SCMP_ACT_ERRNO(ENOSYS));


### PR DESCRIPTION
Musl uses readv/writev for stdio, so we need to allow them for the tests to pass.

Fixes #206