### PR TITLE
Bump version to 1.0.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([composefs], [1.0.0], [giuseppe@scrivano.org])
+AC_INIT([composefs], [1.0.1], [giuseppe@scrivano.org])
 AC_CONFIG_SRCDIR([tools/mkcomposefs.c])
 AC_CONFIG_HEADERS([config.h])
 AC_SYS_LARGEFILE
@@ -22,7 +22,7 @@ AC_SYS_LARGEFILE
 
 m4_define([LIBCOMPOSEFS_VERSION_MAJOR], [1])
 m4_define([LIBCOMPOSEFS_VERSION_MINOR], [0])
-m4_define([LIBCOMPOSEFS_VERSION_MICRO], [0])
+m4_define([LIBCOMPOSEFS_VERSION_MICRO], [1])
 
 LT_PREREQ([2.2.6])
 LT_INIT()


### PR DESCRIPTION
Changes since 1.0.0:

* mkcomposefs now supports --from-file which reads image descriptions in the format of `composefs-info dump` output.
* composefs-info dump output now shows content and hardlink target
* mount.composefs now uses the new mount api on recent kernels, which fixes a regression in escaping commas in upperdir/lowerdir/workdir options.
* lcfs_node_set_payload() now accepts NULL to unset
* Some performance improvements
* Fixed errors in error reporting
* Added more manpages