### PR TITLE
Use go-md2man for building manpages

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -28,11 +28,11 @@ if ENABLE_MAN
 
 man/%.1: man/%.md
 	mkdir -p man
-	${PANDOC} $+ -s -t man > $@
+	${MD2MAN} -in $^ -out $@
 
 man/%.5: man/%.md
 	mkdir -p man
-	${PANDOC} $+ -s -t man > $@
+	${MD2MAN} -in $^ -out $@
 
 man1_MANS = $(MAN1PAGES:.md=.1)
 man5_MANS = $(MAN5PAGES:.md=.5)

--- a/composefs.spec.in
+++ b/composefs.spec.in
@@ -7,7 +7,7 @@ License:        GPL-3.0-or-later AND LGPL-2.0-or-later AND Apache-2.0
 URL:            https://github.com/containers/composefs
 Source0:        https://github.com/containers/composefs/releases/download/v%{version}/%{name}-%{version}.tar.xz
 
-BuildRequires:  gcc automake libtool openssl-devel pandoc fuse3-devel
+BuildRequires:  gcc automake libtool openssl-devel go-md2man fuse3-devel
 Requires:       %{name}-libs = %{version}-%{release}
 
 %description

--- a/configure.ac
+++ b/configure.ac
@@ -104,10 +104,10 @@ AC_ARG_ENABLE(man,
               enable_man=maybe)
 
 AS_IF([test "$enable_man" != no], [
-  AC_PATH_PROG([PANDOC], [pandoc])
-  AS_IF([test -z "$PANDOC"], [
+  AC_PATH_PROG([MD2MAN], [go-md2man])
+  AS_IF([test -z "$MD2MAN"], [
     AS_IF([test "$enable_man" = yes], [
-      AC_MSG_ERROR([pandoc is required for --enable-man])
+      AC_MSG_ERROR([go-md2man is required for --enable-man])
     ])
     enable_man=no
   ],[


### PR DESCRIPTION
This allows avoiding the pandoc build dependency in downstream distributions (which is important for RHEL which does not provide pandoc) at the price of upstream developers requiring it.

The alternative would be to add the manpages to source control, so that pandoc would only be needed when modifying the markdown sources.

This is needed to remove the unwanted pandoc from the ELN buildroot while still providing man pages.
