### PR TITLE
Drop i686 from spec

### DIFF
--- a/composefs.spec.in
+++ b/composefs.spec.in
@@ -10,6 +10,9 @@ Source0:        https://github.com/containers/composefs/releases/download/v%{ver
 BuildRequires:  gcc automake libtool openssl-devel go-md2man fuse3-devel
 Requires:       %{name}-libs = %{version}-%{release}
 
+# https://fedoraproject.org/wiki/Changes/EncourageI686LeafRemoval
+ExcludeArch:    %{ix86}
+
 %description
 Tools to handle creating and mounting composefs images. The composefs
 project combines several underlying Linux features to provide a very


### PR DESCRIPTION
Only certain userspace libraries are still needed for compatibility on i686, and composefs is certainly not among them.

This is needed to fix the ELN build after #227, as golang (and hence go-md2man) are disabled there on i686.