### PR TITLE
writer: Limit to UINT16_MAX xattrs

### DIFF
--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -1389,6 +1389,11 @@ int lcfs_node_set_xattr(struct lcfs_node_s *node, const char *name,
 		return 0;
 	}
 
+	if (node->n_xattrs == UINT16_MAX) {
+		errno = EINVAL;
+		return -1;
+	}
+
 	xattrs = realloc(node->xattrs,
 			 (node->n_xattrs + 1) * sizeof(struct lcfs_xattr_s));
 	if (xattrs == NULL) {


### PR DESCRIPTION
This is the current EROFS limit, and we have a similar check in the writer code.  We should not allow
internal memory representation to go above it.

There's a lot of potential followup work to change our usage of size_t here to be uint16_t, but that can come later.