### PR TITLE
Bump version to 1.0.2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([composefs], [1.0.1], [giuseppe@scrivano.org])
+AC_INIT([composefs], [1.0.2], [giuseppe@scrivano.org])
 AC_CONFIG_SRCDIR([tools/mkcomposefs.c])
 AC_CONFIG_HEADERS([config.h])
 AC_SYS_LARGEFILE


### PR DESCRIPTION
Changes since 1.0.1:

* Dropped composefs-from-json in tests in favour of using the composefs-info dump format.
* libyajl dependency dropped
* libcomposefs now limits the number of xattrs per file to 64k
* Fixed build against libc without reallocarray
* Performance fixes
* go-md2man is used instead of pandoc for manpages
* Minor fixes to spec file