### PR TITLE
Allow building without go-md2man

### DIFF
--- a/composefs.spec.in
+++ b/composefs.spec.in
@@ -1,3 +1,7 @@
+%ifarch %{golang_arches}
+%bcond man 1
+%endif
+
 Name:           composefs
 Version:        @VERSION@
 Release:        1%{?dist}
@@ -7,11 +11,11 @@ License:        GPL-3.0-or-later AND LGPL-2.0-or-later AND Apache-2.0
 URL:            https://github.com/containers/composefs
 Source0:        https://github.com/containers/composefs/releases/download/v%{version}/%{name}-%{version}.tar.xz
 
-BuildRequires:  gcc automake libtool openssl-devel go-md2man fuse3-devel
+BuildRequires:  gcc automake libtool openssl-devel fuse3-devel
+%if %{with man}
+BuildRequires:  go-md2man
+%endif
 Requires:       %{name}-libs = %{version}-%{release}
-
-# https://fedoraproject.org/wiki/Changes/EncourageI686LeafRemoval
-ExcludeArch:    %{ix86}
 
 %description
 Tools to handle creating and mounting composefs images. The composefs
@@ -41,7 +45,9 @@ Library files for %{name}.
 %build
 %configure \
            --disable-static \
+%if %{with man}
            --enable-man \
+%endif
            --with-fuse
 %make_build
 
@@ -64,7 +70,9 @@ rm -rf %{buildroot}%{_libdir}/libcomposefs.la
 %{_bindir}/mkcomposefs
 %{_bindir}/composefs-info
 %{_sbindir}/mount.composefs
+%if %{with man}
 %{_mandir}/man*/*
+%endif
 
 %changelog
 * Mon Oct 16 2023 Stephen Smoogen <ssmoogen@redhat.com>


### PR DESCRIPTION
The cascade of packages which suddenly do not build on i686 due to the introduction of composefs as a dependency is causing issues.  Instead, allow this to be built without manpages.

This is a follow-up to #229.

/cc @cgwalters
