### PR TITLE
writer: Handle errors from `read`

### DIFF
--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -537,6 +537,8 @@ static int read_content(int fd, size_t size, uint8_t *buf)
 
 		if (bytes_read == 0)
 			break;
+		else if (bytes_read < 0)
+			return -1;
 
 		size -= bytes_read;
 		buf += bytes_read;


### PR DESCRIPTION
Yet another picture perfect example of a bug that Wouldn't Happen In Rust.

Noticed by an internal static analyzer.