### PR TITLE
Fix use of new mount API and add a try-verity mount option

### DIFF
--- a/libcomposefs/lcfs-mount.c
+++ b/libcomposefs/lcfs-mount.c
@@ -379,7 +379,14 @@ static errint_t lcfs_mount_ovl(struct lcfs_mount_state_s *state, char *imagemoun
 	if (fd_fs < 0)
 		return -errno;
 
-	int res = syscall_fsconfig(fd_fs, FSCONFIG_SET_STRING, "metacopy", "on", 0);
+	/* Ensure overlayfs is fully supporting the new mount api, not just
+	   via the legacy mechanism that doesn't validate options */
+	int res = syscall_fsconfig(fd_fs, FSCONFIG_SET_STRING, "unsupported",
+				   "unsupported", 0);
+	if (res == 0)
+		return -ENOSYS;
+
+	res = syscall_fsconfig(fd_fs, FSCONFIG_SET_STRING, "metacopy", "on", 0);
 	if (res < 0)
 		return -errno;
 
@@ -395,34 +402,29 @@ static errint_t lcfs_mount_ovl(struct lcfs_mount_state_s *state, char *imagemoun
 	}
 
 	/* Here we're using the new mechanism to append to lowerdir that was added in
-	 * 6.5 (commit b36a5780cb44), because that is the only way to handle escaping
+	 * 6.7 (24e16e385f227), because that is the only way to handle escaping
 	 * of commas (i.e. we don't need to in this case) with the new mount api.
-	 * Also, since 6.5 has data-only lowerdir support we can just always use it.
+	 * Also, since 6.7 has data-only lowerdir support we can just always use it.
 	 *
-	 * For older kernels a lack of append support will make the mount fail with EINVAL
-	 * and print an "empty lowerdir" error, and a lack of comma in the options will
-	 * cause the fsconfig to fail with EINVAL. If any of these happen we fall back to
+	 * For older kernels a lack of append support will make the mount fail with EINVAL,
+	 * and a lack of comma in the options will cause the fsconfig to fail with EINVAL. If any of these happen we fall back to
 	 * the legacy implementation (via ENOSYS).
 	 */
-	res = syscall_fsconfig(fd_fs, FSCONFIG_SET_STRING, "lowerdir", imagemount, 0);
-	/* EINVAL probably the lack of support for commas in options as per above, fallback */
-	if (errno == EINVAL)
-		return -ENOSYS;
-	if (res < 0)
+	res = syscall_fsconfig(fd_fs, FSCONFIG_SET_STRING, "lowerdir+",
+			       imagemount, 0);
+	if (res < 0) {
+		/* EINVAL lack of support for appending as per above, fallback */
+		if (errno == EINVAL)
+			return -ENOSYS;
 		return -errno;
+	}
 
 	for (size_t i = 0; i < state->options->n_objdirs; i++) {
 		const char *objdir = state->options->objdirs[i];
-		cleanup_free char *opt = malloc(strlen(objdir) + 2 + 1);
-		if (opt == NULL)
-			return -ENOMEM;
-		strcpy(opt, "::"); /* starting with : means we append a dataonly lowerdir */
-		strcat(opt, objdir);
-
-		res = syscall_fsconfig(fd_fs, FSCONFIG_SET_STRING, "lowerdir",
-				       opt, 0);
+		res = syscall_fsconfig(fd_fs, FSCONFIG_SET_STRING, "datadir+",
+				       objdir, 0);
 		if (res < 0) {
-			/* EINVAL probably the lack of support for commas in options as per above, fallback */
+			/* EINVAL lack of support for appending as per above, fallback */
 			if (errno == EINVAL)
 				return -ENOSYS;
 			return -errno;
@@ -433,7 +435,7 @@ static errint_t lcfs_mount_ovl(struct lcfs_mount_state_s *state, char *imagemoun
 		res = syscall_fsconfig(fd_fs, FSCONFIG_SET_STRING, "upperdir",
 				       options->upperdir, 0);
 		if (res < 0) {
-			/* EINVAL probably the lack of support for commas in options as per above, fallback */
+			/* EINVAL lack of support for appending as per above, fallback */
 			if (errno == EINVAL)
 				return -ENOSYS;
 			return -errno;

--- a/libcomposefs/lcfs-mount.h
+++ b/libcomposefs/lcfs-mount.h
@@ -36,6 +36,7 @@ enum lcfs_mount_flags_t {
 	LCFS_MOUNT_FLAGS_REQUIRE_VERITY = (1 << 0),
 	LCFS_MOUNT_FLAGS_READONLY = (1 << 1),
 	LCFS_MOUNT_FLAGS_IDMAP = (1 << 3),
+	LCFS_MOUNT_FLAGS_TRY_VERITY = (1 << 4),
 
 	LCFS_MOUNT_FLAGS_MASK = (1 << 5) - 1,
 };

--- a/tools/mountcomposefs.c
+++ b/tools/mountcomposefs.c
@@ -52,6 +52,7 @@ static void usage(const char *argv0)
 		"  basedir=PATH[:PATH]    Specify location of basedir(s)\n"
 		"  digest=DIGEST          Specify required image digest\n"
 		"  verity                 Require all files to have specified and valid fs-verity digests\n"
+		"  tryverity              If supported by kernel, require fs-verity\n"
 		"  ro                     Read only\n"
 		"  rw                     Read/write\n"
 		"  upperdir               Overlayfs upperdir\n"
@@ -118,6 +119,7 @@ int main(int argc, char **argv)
 	const char *opt_upperdir = NULL;
 	const char *opt_workdir = NULL;
 	bool opt_verity = false;
+	bool opt_tryverity = false;
 	bool opt_ro = false;
 	int opt, fd, res, userns_fd;
 
@@ -173,6 +175,8 @@ int main(int argc, char **argv)
 			opt_digest = value;
 		} else if (strcmp("verity", key) == 0) {
 			opt_verity = true;
+		} else if (strcmp("tryverity", key) == 0) {
+			opt_tryverity = true;
 		} else if (strcmp("upperdir", key) == 0) {
 			if (value == NULL)
 				errx(EXIT_FAILURE,
@@ -236,6 +240,8 @@ int main(int argc, char **argv)
 
 	if (opt_verity || opt_digest != NULL)
 		options.flags |= LCFS_MOUNT_FLAGS_REQUIRE_VERITY;
+	else if (opt_tryverity)
+		options.flags |= LCFS_MOUNT_FLAGS_TRY_VERITY;
 	if (opt_ro)
 		options.flags |= LCFS_MOUNT_FLAGS_READONLY;
 


### PR DESCRIPTION
It turns out that the new append mechanism that was added in linux 6.5 that we used was disabled, and a new mechanism was added in 6.7. This changes the new-mount-api code to use the new approach.

Also, I added a "try verity" option that can be used for example by ostree to support fs-verity in an optional way to protect against accidental modification.  This can be passed in if you know fs-verity was enabled on the files, and will not fail if the kernel doesn't support the overlayfs verity= option. In comparison, for the signed usecase we must fail if verity is not supported.