### PR TITLE
mkcomposefs: Handle NULL from strndup()

### DIFF
--- a/tools/mkcomposefs.c
+++ b/tools/mkcomposefs.c
@@ -212,6 +212,8 @@ static struct lcfs_node_s *lookup_parent_path(struct lcfs_node_s *node,
 	}
 
 	cleanup_free char *name = strndup(start, path - start);
+	if (name == NULL)
+		oom();
 
 	struct lcfs_node_s *child = lcfs_node_lookup_child(node, name);
 	if (child == NULL)
@@ -233,6 +235,8 @@ static struct lcfs_node_s *lookup_path(struct lcfs_node_s *node, const char *pat
 		path++;
 
 	cleanup_free char *name = strndup(start, path - start);
+	if (name == NULL)
+		oom();
 
 	struct lcfs_node_s *child = lcfs_node_lookup_child(node, name);
 	if (child == NULL)


### PR DESCRIPTION
There is already a check here:

https://github.com/containers/composefs/blob/e63786d4c7e573f75c2db410b746521d11e7b105/tools/mkcomposefs.c#L246-L248

Adding such check in two other places.