### PR TITLE
writer: Fix (almost certainly unreachable) overflow

### DIFF
--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -689,7 +689,7 @@ struct lcfs_node_s *lcfs_load_node_from_file(int dirfd, const char *fname,
 	} else if ((sb.st_mode & S_IFMT) == S_IFLNK) {
 		char target[PATH_MAX + 1];
 
-		r = readlinkat(dirfd, fname, target, sizeof(target));
+		r = readlinkat(dirfd, fname, target, sizeof(target) - 1);
 		if (r < 0)
 			return NULL;
 


### PR DESCRIPTION
A static analyzer warned about us potentially overflowing here, which I don't think is actually possible because `readlink` should never return a size greater than `PATH_MAX`.

Nevertheless, fix the math.

Note this is another bug that Wouldn't Happen in Rust.