### PR TITLE
Support older linux headers

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,23 @@ jobs:
         with:
           name: composefs.tar
           path: composefs.tar
+  build-baseline:
+    runs-on: ubuntu-latest
+    name: "Build on Ubuntu Focal"
+    container: ubuntu:focal
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          apt-get update -y
+          ALLOW_MISSING="libfsverity-dev" ./hacking/installdeps.sh
+      - name: Configure
+        run: |
+          ./autogen.sh
+          ./configure --prefix=/usr --sysconfdir=/etc --libdir=/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH) CFLAGS='-Wall -Werror'
+      - name: Build
+        run: make -j $(nproc) CFLAGS='-fsanitize=address -fsanitize=undefined'
   build-unit-cross:
     runs-on: ubuntu-latest
     name: Build on ${{ matrix.arch }}

--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,17 @@ m4_ifdef([PKG_INSTALLDIR], [PKG_INSTALLDIR], AC_SUBST([pkgconfigdir], ${libdir}/
 PKGCONFIG_REQUIRES=
 PKGCONFIG_REQUIRES_PRIVATELY=
 
+AC_MSG_CHECKING([for MOUNT_ATTR_IDMAP])
+AC_COMPILE_IFELSE(
+	[AC_LANG_PROGRAM([
+			#include <sys/mount.h>
+			#include <linux/mount.h>
+	],[int foo = MOUNT_ATTR_IDMAP;]
+	)],
+	[AC_MSG_RESULT(yes)
+		AC_DEFINE([HAVE_MOUNT_ATTR_IDMAP], 1, [Define if MOUNT_ATTR_IDMAP is available in linux/mount.h])],
+	[AC_MSG_RESULT(no)])
+
 AC_MSG_CHECKING([for new mount API (fsconfig)])
 AC_COMPILE_IFELSE(
 	[AC_LANG_SOURCE([[

--- a/hacking/installdeps.sh
+++ b/hacking/installdeps.sh
@@ -1,4 +1,40 @@
 #!/bin/bash
 set -xeuo pipefail
 export DEBIAN_FRONTEND=noninteractive
-apt-get install -y automake libtool autoconf autotools-dev git make gcc libssl-dev libfsverity-dev pkg-config libfuse3-dev python3 libcap2-bin
+
+PACKAGES=" \
+    automake \
+    libtool \
+    autoconf \
+    autotools-dev \
+    git \
+    make \
+    gcc \
+    libssl-dev \
+    libfsverity-dev \
+    pkg-config \
+    libfuse3-dev \
+    python3 \
+    libcap2-bin \
+"
+
+# Split required and optional packages based on input variable ALLOW_MISSING:
+PACKAGES_REQUIRED=""
+PACKAGES_OPTIONAL=""
+
+for pkg in $PACKAGES; do
+    if [[ " ${ALLOW_MISSING:-} " == *" ${pkg} "* ]]; then
+	PACKAGES_OPTIONAL+=" ${pkg}"
+    else
+	PACKAGES_REQUIRED+=" ${pkg}"
+    fi
+done
+
+# Install packages:
+if [ -n "${PACKAGES_REQUIRED}" ]; then
+    apt-get install -y $PACKAGES_REQUIRED
+fi
+
+if [ -n "${PACKAGES_OPTIONAL}" ]; then
+    apt-get install -y --ignore-missing $PACKAGES_OPTIONAL || true
+fi

--- a/libcomposefs/lcfs-mount.c
+++ b/libcomposefs/lcfs-mount.c
@@ -108,6 +108,7 @@ static int syscall_move_mount(int from_dfd, const char *from_pathname, int to_df
 #endif
 }
 
+#ifdef HAVE_MOUNT_ATTR_IDMAP
 static int syscall_mount_setattr(int dfd, const char *path, unsigned int flags,
 				 struct mount_attr *attr, size_t usize)
 {
@@ -122,6 +123,7 @@ static int syscall_mount_setattr(int dfd, const char *path, unsigned int flags,
 	return -1;
 #endif
 }
+#endif
 
 #define MAX_DIGEST_SIZE 64
 
@@ -526,6 +528,7 @@ static errint_t lcfs_mount_erofs(const char *source, const char *target,
 		return -errno;
 
 	if (use_idmap) {
+#ifdef HAVE_MOUNT_ATTR_IDMAP
 		struct mount_attr attr = {
 			.attr_set = MOUNT_ATTR_IDMAP,
 			.userns_fd = state->options->idmap_fd,
@@ -535,6 +538,9 @@ static errint_t lcfs_mount_erofs(const char *source, const char *target,
 					    sizeof(struct mount_attr));
 		if (res < 0)
 			return -errno;
+#else
+		return -ENOTSUP;
+#endif
 	}
 
 	res = syscall_move_mount(fd_mnt, "", AT_FDCWD, target,

--- a/libcomposefs/lcfs-mount.c
+++ b/libcomposefs/lcfs-mount.c
@@ -49,6 +49,20 @@
 #include "lcfs-utils.h"
 #include "lcfs-internal.h"
 
+#ifndef LOOP_CONFIGURE
+/* Snippet from util-linux/include/loopdev.h */
+/*
+ * Since Linux v5.8-rc1 (commit 3448914e8cc550ba792d4ccc74471d1ca4293aae)
+ */
+#define LOOP_CONFIGURE 0x4C0A
+struct loop_config {
+	uint32_t fd;
+	uint32_t block_size;
+	struct loop_info64 info;
+	uint64_t __reserved[8];
+};
+#endif
+
 static int syscall_fsopen(const char *fs_name, unsigned int flags)
 {
 #if defined __NR_fsopen


### PR DESCRIPTION
This aims to tackle https://github.com/containers/composefs/issues/252, i.e. allowing the build when macros MOUNT_ATTR_IDMAP and LOOP_CONFIGURE along with related structures are not available in the user API of the Linux kernel.
