### PR TITLE
mountcomposefs, mkcomposefs: Add missing options to usage information

### DIFF
--- a/man/mount.composefs.md
+++ b/man/mount.composefs.md
@@ -40,6 +40,10 @@ options when passed via the `-o OPTIONS` argument.
 
     This option also implies **verity**.
 
+**idmap**=*PATH*
+:   Specify a path to a user namespace whose ID mapping should be used.
+    The typical format for this type of path is `/proc/<pid>/ns/user`
+
 **verity**
 :   If this is specified, all files in the *IMAGE* must specify an fs-verity
     digest, and all the files in the base dirs must have a matching fs-verity

--- a/tools/mkcomposefs.c
+++ b/tools/mkcomposefs.c
@@ -943,6 +943,7 @@ static void usage(const char *argv0)
 		"Options:\n"
 		"  --digest-store=PATH   Store content files in this directory\n"
 		"  --use-epoch           Make all mtimes zero\n"
+		"  --skip-devices        Don't store device nodes\n"
 		"  --skip-xattrs         Don't store file xattrs\n"
 		"  --user-xattrs         Only store user.* xattrs\n"
 		"  --print-digest        Print the digest of the image\n"

--- a/tools/mountcomposefs.c
+++ b/tools/mountcomposefs.c
@@ -51,6 +51,7 @@ static void usage(const char *argv0)
 		"Supported options:\n"
 		"  basedir=PATH[:PATH]    Specify location of basedir(s)\n"
 		"  digest=DIGEST          Specify required image digest\n"
+		"  idmap=PATH             Specify path to a user namespace whose ID mapping should be used\n"
 		"  verity                 Require all files to have specified and valid fs-verity digests\n"
 		"  tryverity              If supported by kernel, require fs-verity\n"
 		"  ro                     Read only\n"


### PR DESCRIPTION
Adding a few options that were missing