### PR TITLE
erofs, mkcomposefs: Handle error from lcfs_node_set_content()

### DIFF
--- a/libcomposefs/lcfs-writer-erofs.c
+++ b/libcomposefs/lcfs-writer-erofs.c
@@ -1602,6 +1602,7 @@ static struct lcfs_node_s *lcfs_build_node_from_image(struct lcfs_image_data *da
 	size_t tail_size;
 	const uint8_t *tail_data;
 	const uint8_t *oob_data;
+	int ret;
 
 	cino = lcfs_image_get_erofs_inode(data, nid);
 	if (cino == NULL)
@@ -1742,7 +1743,10 @@ static struct lcfs_node_s *lcfs_build_node_from_image(struct lcfs_image_data *da
 		if (tailpacked)
 			memcpy(content + oob_size, tail_data, tail_size);
 
-		lcfs_node_set_content(node, content, file_size);
+		ret = lcfs_node_set_content(node, content, file_size);
+		if (ret < 0) {
+			return NULL;
+		}
 	}
 
 	if (xattr_icount > 0) {

--- a/tools/mkcomposefs.c
+++ b/tools/mkcomposefs.c
@@ -397,6 +397,8 @@ static char *tree_resolve_hardlinks(dump_info *info)
 
 static char *tree_from_dump_line(dump_info *info, const char *line, size_t line_len)
 {
+	int ret;
+
 	/* Split out all fixed fields */
 	field_info fields[FIELD_XATTRS_START];
 	for (int i = 0; i < FIELD_XATTRS_START; i++) {
@@ -501,8 +503,11 @@ static char *tree_from_dump_line(dump_info *info, const char *line, size_t line_
 	lcfs_node_set_rdev(node, rdev);
 	lcfs_node_set_mtime(node, &mtime);
 	lcfs_node_set_payload(node, payload);
-	if (content)
-		lcfs_node_set_content(node, (uint8_t *)content, size);
+	if (content) {
+		ret = lcfs_node_set_content(node, (uint8_t *)content, size);
+		if (ret < 0)
+			oom();
+	}
 
 	if (digest) {
 		uint8_t raw[LCFS_DIGEST_SIZE];


### PR DESCRIPTION
Check for errors in lcfs_node_set_content()  return value
 