### PR TITLE
handle NULL from lcfs_node_new() and move errno code into the function

### DIFF
--- a/libcomposefs/lcfs-writer-erofs.c
+++ b/libcomposefs/lcfs-writer-erofs.c
@@ -1188,7 +1188,6 @@ static int add_overlay_whiteouts(struct lcfs_node_s *root)
 
 		child = lcfs_node_new();
 		if (child == NULL) {
-			errno = ENOMEM;
 			return -1;
 		}
 
@@ -1236,7 +1235,6 @@ static int rewrite_tree_node_for_erofs(struct lcfs_ctx_s *ctx,
 		if (existing == NULL) {
 			struct lcfs_node_s *link = lcfs_node_new();
 			if (link == NULL) {
-				errno = ENOMEM;
 				return -1;
 			}
 			lcfs_node_make_hardlink(link, node);
@@ -1251,7 +1249,6 @@ static int rewrite_tree_node_for_erofs(struct lcfs_ctx_s *ctx,
 		if (existing == NULL) {
 			struct lcfs_node_s *link = lcfs_node_new();
 			if (link == NULL) {
-				errno = ENOMEM;
 				return -1;
 			}
 			lcfs_node_make_hardlink(link, parent);
@@ -1609,7 +1606,6 @@ static struct lcfs_node_s *lcfs_build_node_from_image(struct lcfs_image_data *da
 
 	node = lcfs_node_new();
 	if (node == NULL) {
-		errno = ENOMEM;
 		return NULL;
 	}
 

--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -467,8 +467,10 @@ static int read_xattrs(struct lcfs_node_s *ret, int dirfd, const char *fname,
 struct lcfs_node_s *lcfs_node_new(void)
 {
 	struct lcfs_node_s *node = calloc(1, sizeof(struct lcfs_node_s));
-	if (node == NULL)
+	if (node == NULL) {
+		errno = ENOMEM;
 		return NULL;
+	}
 
 	node->ref_count = 1;
 	node->inode.st_nlink = 1;

--- a/tools/mkcomposefs.c
+++ b/tools/mkcomposefs.c
@@ -423,6 +423,9 @@ static char *tree_from_dump_line(dump_info *info, const char *line, size_t line_
 		return err;
 
 	cleanup_node struct lcfs_node_s *node = lcfs_node_new();
+	if (node == NULL) {
+		oom();
+	}
 	lcfs_node_set_mode(node, mode);
 
 	err = tree_add_node(info, path, node);


### PR DESCRIPTION
The interesting commit edits
tools/mkcomposefs.c

The other commit is just an attempt to reduce the number of source code lines.
