### PR TITLE
writer: Set errno

### DIFF
--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -724,8 +724,8 @@ int lcfs_version_from_fd(int fd)
 	}
 	if (lcfs_u32_from_file(header->magic) != LCFS_EROFS_MAGIC ||
 	    lcfs_u32_from_file(header->version) != LCFS_EROFS_VERSION) {
-		errno = EINVAL;
 		munmap(header, header_size);
+		errno = EINVAL;
 		return -1;
 	}
 
@@ -1155,6 +1155,7 @@ struct lcfs_node_s *lcfs_node_clone(struct lcfs_node_s *node)
 			if (key == NULL || value == NULL) {
 				free(key);
 				free(value);
+				errno = ENOMEM;
 				return NULL;
 			}
 			new->xattrs[i].key = key;


### PR DESCRIPTION
According to [errno(3)](https://man7.org/linux/man-pages/man3/errno.3.html) a function that succeeds is allowed to change errno.
 What if memdup() succeeds? 

I changed  the code to match how it's written here
https://github.com/containers/composefs/blob/d5ffbeb6844cdbe029f9c10cfa98239e2d6b1570/libcomposefs/lcfs-writer.c#L1472
