### PR TITLE
Added multithreading support for mkcomposefs

### DIFF
--- a/libcomposefs/lcfs-writer.h
+++ b/libcomposefs/lcfs-writer.h
@@ -154,4 +154,7 @@ LCFS_EXTERN int lcfs_compute_fsverity_from_fd(uint8_t *digest, int fd);
 LCFS_EXTERN int lcfs_compute_fsverity_from_data(uint8_t *digest, uint8_t *data,
 						size_t data_len);
 
+LCFS_EXTERN int lcfs_node_set_from_content(struct lcfs_node_s *node, int dirfd,
+					   const char *fname, int buildflags);
+
 #endif

--- a/man/mkcomposefs.md
+++ b/man/mkcomposefs.md
@@ -70,6 +70,10 @@ will be a mountable composefs image.
     actual image format version used will be adjusted upwards if that
     is beneficial for the image, up to the max version.
 
+**\-\-threads**=*count*
+:   Number of threads to be used to calculate the file digests and copy.
+    Default thread count is the number of processors when *--threads* is not specified.
+
 # FORMAT VERSIONING
 
 Composefs images are binary reproduceable, meaning that for a given


### PR DESCRIPTION
This resolves #249 and results in 10x improvement for digest calculation and file copy.

Please refer the below document for details about the issue and the change. I would like to know your thoughts.
[threading.md](https://github.com/containers/composefs/files/14743119/threading.md)


