### PR TITLE
lcfs-fsverity: Add _GNU_SOURCE feature test define

### DIFF
--- a/libcomposefs/lcfs-fsverity.c
+++ b/libcomposefs/lcfs-fsverity.c
@@ -14,6 +14,8 @@
    You should have received a copy of the GNU Lesser General Public License
    along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
+#define _GNU_SOURCE
+
 #include "config.h"
 
 #include <sys/stat.h>


### PR DESCRIPTION
This file uses htole64(), so it should define _GNU_SOURCE.