### PR TITLE
Update clang-format

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -103,7 +103,7 @@ jobs:
       - name: Integration tests
         run: sudo ./tests/integration.sh
   clang-format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/libcomposefs/erofs_fs_wrapper.h
+++ b/libcomposefs/erofs_fs_wrapper.h
@@ -35,12 +35,16 @@ static inline __u64 le64_to_cpu(__u64 val)
 }
 
 /* Note: These only do power of 2 */
+#ifndef round_up
 #define __round_mask(x, y) ((__typeof__(x))((y)-1))
 #define round_up(x, y) ((((x)-1) | __round_mask(x, y)) + 1)
 #define round_down(x, y) ((x) & ~__round_mask(x, y))
+#endif
 
+#ifndef ALIGN_TO
 #define ALIGN_TO(_offset, _align_size)                                         \
 	(((_offset) + _align_size - 1) & ~(_align_size - 1))
+#endif
 
 #define BIT(nr)  (((uint64_t) 1) << (nr))
 #define BUILD_BUG_ON(condition) ((void)sizeof(char[1 - 2 * !!(condition)]))

--- a/libcomposefs/lcfs-internal.h
+++ b/libcomposefs/lcfs-internal.h
@@ -69,8 +69,8 @@ typedef int errint_t;
 #define ALIGN_TO(_offset, _align_size)                                         \
 	(((_offset) + _align_size - 1) & ~(_align_size - 1))
 
-#define __round_mask(x, y) ((__typeof__(x))((y)-1))
-#define round_up(x, y) ((((x)-1) | __round_mask(x, y)) + 1)
+#define __round_mask(x, y) ((__typeof__(x))((y) - 1))
+#define round_up(x, y) ((((x) - 1) | __round_mask(x, y)) + 1)
 #define round_down(x, y) ((x) & ~__round_mask(x, y))
 
 #define LCFS_MAX_NAME_LENGTH 255 /* max len of file name excluding NULL */


### PR DESCRIPTION
Update to ubuntu-24.04 as our canonical formatter, which people are now more likely to have locally.