### PR TITLE
lib: two new fsverity APIs

### DIFF
--- a/libcomposefs/lcfs-internal.h
+++ b/libcomposefs/lcfs-internal.h
@@ -42,6 +42,9 @@ typedef int errint_t;
  */
 #define LCFS_BUILD_INLINE_FILE_SIZE_LIMIT 64
 
+/* What may be returned by the kernel for digests */
+#define MAX_DIGEST_SIZE 64
+
 #define OVERLAY_XATTR_USER_PREFIX "user."
 #define OVERLAY_XATTR_TRUSTED_PREFIX "trusted."
 #define OVERLAY_XATTR_PARTIAL_PREFIX "overlay."

--- a/libcomposefs/lcfs-mount.c
+++ b/libcomposefs/lcfs-mount.c
@@ -139,8 +139,6 @@ static int syscall_mount_setattr(int dfd, const char *path, unsigned int flags,
 }
 #endif
 
-#define MAX_DIGEST_SIZE 64
-
 struct lcfs_mount_state_s {
 	const char *image_path;
 	const char *mountpoint;

--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -635,6 +635,28 @@ static int read_content(int fd, size_t size, uint8_t *buf)
 	return 0;
 }
 
+// Given a file descriptor, enable fsverity.  This
+// is a thin wrapper for the underlying `FS_IOC_ENABLE_VERITY`
+// ioctl.  For example, it is an error if the file already
+// has verity enabled.
+int lcfs_fd_enable_fsverity(int fd)
+{
+	struct fsverity_enable_arg arg = {};
+
+	arg.version = 1;
+	arg.hash_algorithm = FS_VERITY_HASH_ALG_SHA256;
+	arg.block_size = 4096;
+	arg.salt_size = 0;
+	arg.salt_ptr = 0;
+	arg.sig_size = 0;
+	arg.sig_ptr = 0;
+
+	if (ioctl(fd, FS_IOC_ENABLE_VERITY, &arg) != 0) {
+		return -errno;
+	}
+	return 0;
+}
+
 static void digest_to_path(const uint8_t *csum, char *buf)
 {
 	static const char hexchars[] = "0123456789abcdef";

--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -22,14 +22,17 @@
 #include "lcfs-writer.h"
 #include "lcfs-utils.h"
 #include "lcfs-fsverity.h"
+#include "lcfs-mount.h"
 #include "lcfs-erofs.h"
 #include "hash.h"
 
 #include <errno.h>
 #include <string.h>
+#include <linux/fsverity.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <sys/ioctl.h>
 #include <fcntl.h>
 #include <dirent.h>
 #include <sys/xattr.h>
@@ -521,10 +524,51 @@ int lcfs_compute_fsverity_from_content(uint8_t *digest, void *file, lcfs_read_cb
 	return 0;
 }
 
+// Given a file descriptor, perform an in-memory computation of its fsverity
+// digest.  Note that the computation starts from the current offset position of
+// the file.
 int lcfs_compute_fsverity_from_fd(uint8_t *digest, int fd)
 {
 	int _fd = fd;
 	return lcfs_compute_fsverity_from_content(digest, &_fd, fsverity_read_cb);
+}
+
+// Given a file descriptor, first query the kernel for its fsverity digest.  If
+// it is not available in the kernel, perform an in-memory computation.  The file
+// position will always be reset to zero if needed.
+int lcfs_fd_get_fsverity(uint8_t *digest, int fd)
+{
+	struct {
+		struct fsverity_digest fsv;
+		char buf[MAX_DIGEST_SIZE];
+	} buf;
+
+	// First, ask the kernel if the file already has fsverity; if so we just return
+	// that.
+	buf.fsv.digest_size = MAX_DIGEST_SIZE;
+	int res = ioctl(fd, FS_IOC_MEASURE_VERITY, &buf.fsv);
+	if (res == -1) {
+		// Under this condition, the file didn't have fsverity enabled or the
+		// kernel doesn't support it at all.  We need to compute it in the current process.
+		if (errno == ENODATA || errno == EOPNOTSUPP || errno == ENOTTY) {
+			// For consistency ensure we start from the beginning.  We could
+			// avoid this by using pread() in the future.
+			if (lseek(fd, 0, SEEK_SET) < 0)
+				return -errno;
+			return lcfs_compute_fsverity_from_fd(digest, fd);
+		}
+		// In this case, we found an unexpected error
+		return -errno;
+	}
+	// The file has fsverity enabled, but with an unexpected different algorithm (e.g. sha512).
+	// This is going to be a weird corner case.  For now, we error out.
+	if (buf.fsv.digest_size != LCFS_DIGEST_SIZE) {
+		return -EWRONGVERITY;
+	}
+
+	memcpy(digest, buf.buf, LCFS_DIGEST_SIZE);
+
+	return 0;
 }
 
 int lcfs_compute_fsverity_from_data(uint8_t *digest, uint8_t *data, size_t data_len)

--- a/libcomposefs/lcfs-writer.h
+++ b/libcomposefs/lcfs-writer.h
@@ -153,6 +153,7 @@ LCFS_EXTERN int lcfs_compute_fsverity_from_content(uint8_t *digest, void *file,
 LCFS_EXTERN int lcfs_compute_fsverity_from_fd(uint8_t *digest, int fd);
 LCFS_EXTERN int lcfs_compute_fsverity_from_data(uint8_t *digest, uint8_t *data,
 						size_t data_len);
+LCFS_EXTERN int lcfs_fd_get_fsverity(uint8_t *digest, int fd);
 
 LCFS_EXTERN int lcfs_node_set_from_content(struct lcfs_node_s *node, int dirfd,
 					   const char *fname, int buildflags);

--- a/libcomposefs/lcfs-writer.h
+++ b/libcomposefs/lcfs-writer.h
@@ -157,5 +157,6 @@ LCFS_EXTERN int lcfs_fd_get_fsverity(uint8_t *digest, int fd);
 
 LCFS_EXTERN int lcfs_node_set_from_content(struct lcfs_node_s *node, int dirfd,
 					   const char *fname, int buildflags);
+LCFS_EXTERN int lcfs_fd_enable_fsverity(int fd);
 
 #endif

--- a/man/composefs-info.md
+++ b/man/composefs-info.md
@@ -31,6 +31,9 @@ several sub-commands:
     accepted as input to mkcomposefs if the --from-file
     option is used.
 
+**measure-file**
+:    Interpret the provided paths as generic files, and print their fsverity digest.
+
 # OPTIONS
 
 The provided *IMAGE* argument must be a composefs file. Multiple images

--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -62,6 +62,13 @@ check_fsverity () {
     return 0
 }
 
+assert_streq () {
+    if test "$1" != "$2"; then
+        echo "assertion failed: $1 = $2" 1>&2
+        return 1
+    fi
+}
+
 [[ -v can_whiteout ]] || can_whiteout=$(check_whiteout)
 [[ -v has_fuse ]] || has_fuse=$(if check_fuse; then echo y; else echo n; fi)
 [[ -v has_fsck ]] || has_fsck=$(check_erofs_fsck)

--- a/tests/test-units.sh
+++ b/tests/test-units.sh
@@ -68,7 +68,25 @@ function  test_mount_digest () {
     fi
 }
 
-TESTS="test_inline test_objects test_mount_digest"
+function test_composefs_info_measure_files () {
+    local dir=$1
+    cd $dir
+
+    echo hello world > test.txt
+    echo foo bar baz > test2.txt
+    composefs-info measure-file test.txt test2.txt > out.txt
+    assert_streq "$(head -1 out.txt)" "37061ef2ac4c21bec68489b56138c5780306a4ad7fe6676236ecdf2c9027cd92"
+    assert_streq "$(tail -1 out.txt)" "91e7d88cb7bc9cf6d8db3b0ecf89af4abf204bef5b3ade5113d5b62ef374e70b"
+
+    if [ $has_fsverity = y ]; then
+        fsverity enable --hash-alg=256 test.txt
+        digest=$(composefs-info measure-file test.txt)
+        assert_streq "$digest" "37061ef2ac4c21bec68489b56138c5780306a4ad7fe6676236ecdf2c9027cd92"
+    fi
+    cd -
+}
+
+TESTS="test_inline test_objects test_mount_digest test_composefs_info_measure_files"
 res=0
 for i in $TESTS; do
     testdir=$(mktemp -d $workdir/$i.XXXXXX)

--- a/tools/mkcomposefs.c
+++ b/tools/mkcomposefs.c
@@ -702,24 +702,6 @@ static int join_paths(char **out, const char *path1, const char *path2)
 	return asprintf(out, "%.*s%s%s", len, path1, sep, path2);
 }
 
-static errint_t enable_verity(int fd)
-{
-	struct fsverity_enable_arg arg = {};
-
-	arg.version = 1;
-	arg.hash_algorithm = FS_VERITY_HASH_ALG_SHA256;
-	arg.block_size = 4096;
-	arg.salt_size = 0;
-	arg.salt_ptr = 0;
-	arg.sig_size = 0;
-	arg.sig_ptr = 0;
-
-	if (ioctl(fd, FS_IOC_ENABLE_VERITY, &arg) != 0) {
-		return -errno;
-	}
-	return 0;
-}
-
 static void cleanup_unlink_freep(void *pp)
 {
 	char *filename = *(char **)pp;
@@ -981,7 +963,7 @@ static int copy_file_with_dirs_if_needed(const char *src, const char *dst_base,
 		}
 
 		if (fstat(dfd, &statbuf) == 0) {
-			err = enable_verity(dfd);
+			err = lcfs_fd_enable_fsverity(dfd);
 			if (err < 0) {
 				/* Ignore errors, we're only trying to enable it */
 			}


### PR DESCRIPTION
Add API+CLI to get fsverity digests efficiently

- Add an API that first tries to ask the kernel for the fsverity
  digest, and returns it if present, but otherwise does a fallback
  to in-memory computation.  The primary use case here
  is systems which want to canonically index files by their fsverity
  digest (as opposed to e.g. sha256).  If the filesystem in the
  future starts supporting fsverity (as e.g. XFS is slated to do)
  then this allows an efficient in-place upgrade.
- Expose the measurement in the CLI.  `fsverity-utils` isn't
  installed everywhere, and also today composefs makes hard decisions
  (like using sha256) that that project doesn't do.

Signed-off-by: Colin Walters <walters@verbum.org>

---

lib: Add a thin public API wrapper for `FS_IOC_ENABLE_VERITY`

The main thing is this helps ensure that other external
software using the library uses the same fsverity parameters.
There's also the aspect that using ioctl() from some non-C
languages is tricky.

Signed-off-by: Colin Walters <walters@verbum.org>

---
