### PR TITLE
man: Drop `=` as a special escaped character

### DIFF
--- a/man/composefs-dump.md
+++ b/man/composefs-dump.md
@@ -39,10 +39,8 @@ Optionally, these custom escapes are suppored:
  **\\t**
  :    tab
 
- **\\=**
- :    equal
 
-Optional fields tha are not set contain '-', and if a field actually
+Optional fields that are not set contain '-', and if a field actually
 has that particular value it is escaped.
 
 The fixed fields on a line are (all numbers in base 10 unless


### PR DESCRIPTION
It isn't, actually right now.  We could make it one but that would be a compat hazard, and it's just
easier to tell people to hex encode it.