### PR TITLE
Info drop internal xattrs

### DIFF
--- a/libcomposefs/lcfs-internal.h
+++ b/libcomposefs/lcfs-internal.h
@@ -48,25 +48,39 @@ typedef int errint_t;
 #define OVERLAY_XATTR_USER_PREFIX "user."
 #define OVERLAY_XATTR_TRUSTED_PREFIX "trusted."
 #define OVERLAY_XATTR_PARTIAL_PREFIX "overlay."
+// trusted.overlay.
 #define OVERLAY_XATTR_PREFIX                                                   \
 	OVERLAY_XATTR_TRUSTED_PREFIX OVERLAY_XATTR_PARTIAL_PREFIX
+// user.overlay.
 #define OVERLAY_XATTR_USERXATTR_PREFIX                                         \
 	OVERLAY_XATTR_USER_PREFIX OVERLAY_XATTR_PARTIAL_PREFIX
+// trusted.overlay.overlay.
 #define OVERLAY_XATTR_ESCAPE_PREFIX OVERLAY_XATTR_PREFIX "overlay."
+// trusted.overlay.metacopy
 #define OVERLAY_XATTR_METACOPY OVERLAY_XATTR_PREFIX "metacopy"
+// trusted.overlay.redirect
 #define OVERLAY_XATTR_REDIRECT OVERLAY_XATTR_PREFIX "redirect"
+// trusted.overlay.whiteout
 #define OVERLAY_XATTR_WHITEOUT OVERLAY_XATTR_PREFIX "whiteout"
+// trusted.overlay.whiteouts
 #define OVERLAY_XATTR_WHITEOUTS OVERLAY_XATTR_PREFIX "whiteouts"
+// trusted.overlay.opaque
 #define OVERLAY_XATTR_OPAQUE OVERLAY_XATTR_PREFIX "opaque"
 
+// trusted.overlay.overlay.whiteout
 #define OVERLAY_XATTR_ESCAPED_WHITEOUT OVERLAY_XATTR_ESCAPE_PREFIX "whiteout"
+// trusted.overlay.overlay.whiteouts
 #define OVERLAY_XATTR_ESCAPED_WHITEOUTS OVERLAY_XATTR_ESCAPE_PREFIX "whiteouts"
+// trusted.overlay.overlay.opaque
 #define OVERLAY_XATTR_ESCAPED_OPAQUE OVERLAY_XATTR_ESCAPE_PREFIX "opaque"
 
+// user.overlay.whiteout
 #define OVERLAY_XATTR_USERXATTR_WHITEOUT                                       \
 	OVERLAY_XATTR_USERXATTR_PREFIX "whiteout"
+// user.overlay.whiteouts
 #define OVERLAY_XATTR_USERXATTR_WHITEOUTS                                      \
 	OVERLAY_XATTR_USERXATTR_PREFIX "whiteouts"
+// user.overlay.opaque
 #define OVERLAY_XATTR_USERXATTR_OPAQUE OVERLAY_XATTR_USERXATTR_PREFIX "opaque"
 
 #define ALIGN_TO(_offset, _align_size)                                         \

--- a/libcomposefs/lcfs-internal.h
+++ b/libcomposefs/lcfs-internal.h
@@ -67,6 +67,10 @@ typedef int errint_t;
 // trusted.overlay.opaque
 #define OVERLAY_XATTR_OPAQUE OVERLAY_XATTR_PREFIX "opaque"
 
+// user.overlay.overlay.
+#define OVERLAY_XATTR_USERXATTR_ESCAPE_PREFIX                                  \
+	OVERLAY_XATTR_USERXATTR_PREFIX "overlay."
+
 // trusted.overlay.overlay.whiteout
 #define OVERLAY_XATTR_ESCAPED_WHITEOUT OVERLAY_XATTR_ESCAPE_PREFIX "whiteout"
 // trusted.overlay.overlay.whiteouts
@@ -82,6 +86,10 @@ typedef int errint_t;
 	OVERLAY_XATTR_USERXATTR_PREFIX "whiteouts"
 // user.overlay.opaque
 #define OVERLAY_XATTR_USERXATTR_OPAQUE OVERLAY_XATTR_USERXATTR_PREFIX "opaque"
+
+// user.overlay.overlay.opaque
+#define OVERLAY_XATTR_USERXATTR_ESCAPED_OPAQUE                                 \
+	OVERLAY_XATTR_USERXATTR_ESCAPE_PREFIX "opaque"
 
 #define ALIGN_TO(_offset, _align_size)                                         \
 	(((_offset) + _align_size - 1) & ~(_align_size - 1))

--- a/libcomposefs/lcfs-writer-erofs.c
+++ b/libcomposefs/lcfs-writer-erofs.c
@@ -1150,14 +1150,17 @@ static int add_overlayfs_xattrs(struct lcfs_ctx_s *ctx, struct lcfs_node_s *node
 		if (ret < 0)
 			return ret;
 
-		/* Mark dir containing whiteouts with new format as of version 1 */
+		/* Mark dir containing whiteouts with new format as of version 1;
+		 * note the code in composefs-info.c which explicitly skips these.
+		 */
 		if (ctx->options->version >= 1) {
 			ret = lcfs_node_set_xattr(
 				parent, OVERLAY_XATTR_ESCAPED_OPAQUE, "x", 1);
 			if (ret < 0)
 				return ret;
 			ret = lcfs_node_set_xattr(
-				parent, OVERLAY_XATTR_USERXATTR_OPAQUE, "x", 1);
+				parent, OVERLAY_XATTR_USERXATTR_ESCAPED_OPAQUE,
+				"x", 1);
 			if (ret < 0)
 				return ret;
 		}
@@ -1522,6 +1525,7 @@ static int erofs_readdir_block(struct lcfs_image_data *data,
 	return 0;
 }
 
+// Convert an EROFS entry back into a composefs node.
 static int lcfs_build_node_erofs_xattr(struct lcfs_node_s *node, uint8_t name_index,
 				       const char *entry_name, uint8_t name_len,
 				       const char *value, uint16_t value_size)
@@ -1574,6 +1578,17 @@ static int lcfs_build_node_erofs_xattr(struct lcfs_node_s *node, uint8_t name_in
 			memmove(name + strlen(OVERLAY_XATTR_TRUSTED_PREFIX),
 				name + strlen(OVERLAY_XATTR_PREFIX),
 				strlen(name) - strlen(OVERLAY_XATTR_PREFIX) + 1);
+		} else {
+			/* skip */
+			return 0;
+		}
+	}
+	if (str_has_prefix(name, OVERLAY_XATTR_USERXATTR_PREFIX)) {
+		if (str_has_prefix(name, OVERLAY_XATTR_USERXATTR_ESCAPE_PREFIX)) {
+			/* Unescape */
+			memmove(name + strlen(OVERLAY_XATTR_USER_PREFIX),
+				name + strlen(OVERLAY_XATTR_USERXATTR_PREFIX),
+				strlen(name) - strlen(OVERLAY_XATTR_USER_PREFIX) + 1);
 		} else {
 			/* skip */
 			return 0;

--- a/tests/test-units.sh
+++ b/tests/test-units.sh
@@ -19,6 +19,21 @@ function countobjects () {
     find $dir/objects -type f | wc -l
 }
 
+# Test a full cycle of roundtrips through mkcomposefs --from-file, composefs-info dump, etc.
+function test_dump_roundtrip () {
+    testsrcdir=$(cd $(dirname $0) && pwd)
+    pushd $1
+    local src=$testsrcdir/assets/special.dump
+    $BINDIR/mkcomposefs --from-file "${src}" out.cfs
+    $BINDIR/composefs-info dump out.cfs > dump.txt
+    diff -u "${src}" dump.txt
+    $BINDIR/mkcomposefs --from-file dump.txt out2.cfs
+    diff -u out.cfs out2.cfs
+    echo "ok dump roundtrip"
+    popd
+}
+
+
 # Ensure small files are inlined
 function  test_inline () {
     local dir=$1
@@ -86,7 +101,7 @@ function test_composefs_info_measure_files () {
     cd -
 }
 
-TESTS="test_inline test_objects test_mount_digest test_composefs_info_measure_files"
+TESTS="test_dump_roundtrip test_inline test_objects test_mount_digest test_composefs_info_measure_files"
 res=0
 for i in $TESTS; do
     testdir=$(mktemp -d $workdir/$i.XXXXXX)

--- a/tests/test-units.sh
+++ b/tests/test-units.sh
@@ -24,11 +24,12 @@ function test_dump_roundtrip () {
     testsrcdir=$(cd $(dirname $0) && pwd)
     pushd $1
     local src=$testsrcdir/assets/special.dump
+    set -x
     $BINDIR/mkcomposefs --from-file "${src}" out.cfs
     $BINDIR/composefs-info dump out.cfs > dump.txt
-    diff -u "${src}" dump.txt
+    diff -u "${src}" dump.txt || exit 1
     $BINDIR/mkcomposefs --from-file dump.txt out2.cfs
-    diff -u out.cfs out2.cfs
+    diff -u out.cfs out2.cfs || exit 1
     echo "ok dump roundtrip"
     popd
 }

--- a/tools/composefs-info.c
+++ b/tools/composefs-info.c
@@ -236,6 +236,22 @@ static void dump_node(struct lcfs_node_s *node, char *path)
 		size_t value_len;
 		const char *value = lcfs_node_get_xattr(target, name, &value_len);
 
+		// Skip the special xattrs injected by lcfs-writer-erofs.c to
+		// denote a directory containing whiteouts.
+		bool is_opaque_flag =
+			(strcmp(name, OVERLAY_XATTR_OPAQUE) == 0) ||
+			(strcmp(name, OVERLAY_XATTR_USERXATTR_OPAQUE) == 0);
+		bool is_special_x = value_len == 1 && *value == 'x';
+		if (is_opaque_flag && is_special_x) {
+			continue;
+		}
+
+		// Undo the effect of the escaping in add_overlayfs_xattrs
+		if (str_has_prefix(name, OVERLAY_XATTR_ESCAPE_PREFIX)) {
+			name += strlen(OVERLAY_XATTR_ESCAPE_PREFIX);
+		} else if (str_has_prefix(name, OVERLAY_XATTR_USERXATTR_ESCAPE_PREFIX)) {
+			name += strlen(OVERLAY_XATTR_USERXATTR_ESCAPE_PREFIX);
+		}
 		printf(" ");
 		print_escaped(name, -1, ESCAPE_EQUAL);
 		printf("=");


### PR DESCRIPTION
@alexlarsson I took a pass at https://github.com/containers/composefs/pull/282#discussion_r1615667462 (this is only 76.3% baked, I got a little lost a few times in the quoting/processing here) but I'm pretty sure now what we've been writing into the EROFS blob is wrong.  If I'm right about that...I think there's two options:

- Try to roll out our [format version 1.1 game plan](https://github.com/containers/composefs/issues/198)
- Just ignore it...how much do we really care about the `user.` namespace given that we can't mount an EROFS unprivileged anyways and that's super unlikely to change in the future?