### PR TITLE
Bump version to 1.0.4 and lib version to 1.2.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.69])
-AC_INIT([composefs], [1.0.3], [giuseppe@scrivano.org])
+AC_INIT([composefs], [1.0.4], [giuseppe@scrivano.org])
 AC_CONFIG_SRCDIR([tools/mkcomposefs.c])
 AC_CONFIG_HEADERS([config.h])
 AC_SYS_LARGEFILE
@@ -21,7 +21,7 @@ AC_SYS_LARGEFILE
 # (And never do that lightly)
 
 m4_define([LIBCOMPOSEFS_VERSION_MAJOR], [1])
-m4_define([LIBCOMPOSEFS_VERSION_MINOR], [1])
+m4_define([LIBCOMPOSEFS_VERSION_MINOR], [2])
 m4_define([LIBCOMPOSEFS_VERSION_MICRO], [0])
 
 LT_PREREQ([2.2.6])


### PR DESCRIPTION
I'd like to get out a release with at least the new overlayfs mount apis from linux 6.6 to avoid us falling back to legacy mount apis on newer kernels. But having the threaded mkcomposefs would be good too.

Also, we may want https://github.com/containers/composefs/pull/288 landed first

@cgwalters Does it make sense to dist the rust code?

Current release notes:

Changes since 1.0.4:

 * Added LCFS_MOUNT_FLAGS_TRY_VERITY/tryverity mount option to do best-effort fs-verity
 * Use the new loewerdir+ and datadir+ overlayfs mount options from linux 6.6
 * mkcomposefs is now multi-threaded when computing digests and copying files
 * mkcomposefs now uses copy_file_range when copying files
 * Added some initial rust crates to handle composefs dump files
 * Added fuzz tests
 * Documentation updates
 * Fix some crashes and leaks
 * Improve error reporting
 * Fix build on various libc types and versions

Alexander Larsson (5):
      mount: Use the new lowerdir+ and datadir+ options
      lib: Add TRY_VERITY mount option
      mount.composefs: Add tryverity option
      mkcomposefs: Drop newline from error string
      Bump version to 1.0.4 and lib version to 1.2.0

Colin Walters (12):
      writer: Fix (almost certainly unreachable) overflow
      writer: Close mmap leak
      README.md: Drop removed `signed` mount option
      README.md: Fix markdownlint warnings
      man/mount.composefs: Fix a typo and two markdown lint warnings
      Update clang-format
      erofs_fs_wrapper: Avoid duplicate #defines
      lcfs-verity: Add missing include
      Add API+CLI to get fsverity digests efficiently
      lib: Add a thin public API wrapper for `FS_IOC_ENABLE_VERITY`
      man: Drop `=` as a special escaped character
      Add a composefs Rust crate

Divin Ookken Athappan (3):
      refactored lcfs_load_node_from_file to enable multi-threading in mkcomposefs
      added threads in mkcomposefs for digest calculation and file copy
      Added copy_file_range for faster file copy.

Ed Baunton (1):
      man mkcomposefs: detail inlining logic

Erik Sjölund (14):
      mkcomposefs: Handle NULL from strndup()
      fuse: Fix filepath argument in error message
      mountcomposefs, mkcomposefs: Add missing options to usage information
      lib: Add missing lcfs_node_unref()
      erofs, mkcomposefs: Handle error from lcfs_node_set_content()
      erofs: Handle error from lcfs_build_node_from_image()
      lib: Set errno in lcfs_node_new()
      mkcomposefs: Handle NULL from lcfs_node_new()
      writer: Set errno
      mountcomposefs: Handle empty basedir option
      writer: Set errno for unknown format
      erofs: Add missing free() and lcfs_node_unref()
      mkcomposefs: Add missing free()
      fuse: fix spelling in error message

Fathi Boudra (1):
      musl: basename: use portable implementation for basename API

Giuseppe Scrivano (7):
      tools: add fuzzing entrypoint for mkcomposefs
      tests: add fuzzing tests for mkcomposefs
      mkcomposefs: reject dump without root node
      mkcomposefs: tree_from_dump does not exit(2) on errors
      mkcompose: fix crash if no target for hardlink
      .github: run make distcheck as part of the CI
      tests: do not hardcode number of threads

Jan Luebbe (1):
      lcfs-fsverity: Add _GNU_SOURCE feature test define

Rogerio Guerra Borin (3):
      mount: Allow building when macro MOUNT_ATTR_IDMAP is not available
      mount: Allow building when macro LOOP_CONFIGURE is not available
      ci: Add build test for Ubuntu Focal
