### PR TITLE
ci: Test Rust code against current C code

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,22 +17,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  tests:
-    runs-on: ubuntu-latest
-    container: quay.io/coreos-assembler/fcos-buildroot:testing-devel
-    steps:
-      - uses: actions/checkout@v3
-      # xref containers/containers-image-proxy-rs
-      - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: "tests"
-      - name: cargo fmt (check)
-        run: cargo fmt -- --check -l
-      - name: Build
-        run: cargo test --no-run
-      - name: Run tests
-        run: cargo test -- --nocapture --quiet
   cargo-deny:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,26 @@ jobs:
         with:
           name: composefs.tar
           path: composefs.tar
+  # This build doesn't enable ASAN, which e.g. makes it easier to use with Rust
+  build-noasan:
+    runs-on: ubuntu-latest
+    name: "Build"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo ./hacking/installdeps.sh
+      - name: Configure
+        run: ./autogen.sh && ./configure --prefix=/usr --sysconfdir=/etc --libdir=/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH) CFLAGS='-Wall -Werror'
+      - name: Build
+        run: make -j $(nproc)
+      - name: Capture build
+        run: make install DESTDIR=$(pwd)/instroot && tar -C instroot -czf composefs.tar .
+      - name: Upload binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: composefs-noasan.tar
+          path: composefs.tar
   build-baseline:
     runs-on: ubuntu-latest
     name: "Build on Ubuntu Focal"
@@ -102,6 +122,26 @@ jobs:
       - run: sudo tar -C / -xvf composefs.tar
       - name: Integration tests
         run: sudo ./tests/integration.sh
+  rust:
+    needs: build-noasan
+    runs-on: ubuntu-latest
+    steps:
+      - run: sudo apt-get update -y
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Download
+        uses: actions/download-artifact@v2
+        with:
+          name: composefs-noasan.tar
+      - run: sudo tar -C / -xvf composefs.tar
+      - name: Cache Dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: "rust-main"
+      - name: Rust (default features)
+        run: cargo test
+      - name: Rust (all features)
+        run: cargo test --all-features
   clang-format:
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
Our current Rust CI was testing against the *stable* composefs, i.e. whatever happened to be in the current Fedora.

This is too confusing, so move the CI for Rust into the main workflow, and test against the C library under test too.

Also, add a `--all-features` run to add coverage for the feature that enables running against the latest C library.