### PR TITLE
rust: Add mandatory `description` field, other misc changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,3 +153,17 @@ Mount options:
 - `upperdir`: Specify an upperdir for the overlayfs filesystem.
 - `workdir`: Specify an upperdir for the overlayfs filesystem.
 - `idmap`: Specify a path to a user namespace that is used as an idmap.
+
+## Language bindings
+
+### Rust
+
+There are two Rust crates whose source code is included in this repository:
+
+- `composefs-sys`: Low level unsafe `-sys` style wrapper library for linking to the `libcomposefs` C library
+- `composefs-core`: Safe library that depends on `composefs-sys`, and also adds wrappers for invoking the external `mkfs.composefs` and `composefs-info dump` binaries.
+
+### Go
+
+The containers/storage Go library has [code wrapping mkcomposefs](https://github.com/containers/storage/blob/5fe400b7aedc7385e07a938d393d50600ca06299/drivers/overlay/composefs.go#L41)
+that could in theory be extracted to a helper package.

--- a/rust/composefs-core/Cargo.toml
+++ b/rust/composefs-core/Cargo.toml
@@ -2,8 +2,8 @@
 name = "composefs"
 version = "0.1.0"
 edition = "2021"
-description = "Rust composefs"
-keywords = ["composefs", "oci", "opencontainers", "docker", "podman"]
+description = "Rust library for the composefs filesystem"
+keywords = ["composefs"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/containers/composefs"
 rust-version = "1.70.0"

--- a/rust/composefs-sys/Cargo.toml
+++ b/rust/composefs-sys/Cargo.toml
@@ -1,5 +1,7 @@
 [package]
 name = "composefs-sys"
+description = "Rust library wrapping the libcomposefs C library"
+keywords = ["composefs"]
 version = "0.1.0"
 edition = "2021"
 links = "composefs"
@@ -9,8 +11,6 @@ license = "MIT OR Apache-2.0"
 [package.metadata.system-deps.composefs]
 name = "composefs"
 version = "1"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
 # Depend on 1.0.4 APIs


### PR DESCRIPTION
I want to publish `composefs-sys` but a `description` field is required, which is annoyingly not found by `cargo publish --dry-run`.

Do a few other tweaks while we're here, including talking about language bindings in `README.md`.