### PR TITLE
test: remove hardcoded /tmp

### DIFF
--- a/tests/test-checksums.sh
+++ b/tests/test-checksums.sh
@@ -9,8 +9,8 @@ TEST_ASSETS="$3"
 has_fsck=$(check_erofs_fsck)
 
 set -e
-tmpfile=$(mktemp /tmp/lcfs-test.XXXXXX)
-tmpfile2=$(mktemp /tmp/lcfs-test.XXXXXX)
+tmpfile=$(mktemp --tmpdir lcfs-test.XXXXXX)
+tmpfile2=$(mktemp --tmpdir lcfs-test.XXXXXX)
 trap 'rm -rf -- "$tmpfile" "$tmpfile2"' EXIT
 
 for format in erofs ; do

--- a/tests/test-lib.sh
+++ b/tests/test-lib.sh
@@ -24,7 +24,7 @@ assert_file_has_content () {
 }
 
 check_whiteout () {
-    tmpfile=$(mktemp /tmp/lcfs-whiteout.XXXXXX)
+    tmpfile=$(mktemp --tmpdir lcfs-whiteout.XXXXXX)
     rm -f $tmpfile
     if mknod $tmpfile c 0 0 &> /dev/null; then
         echo y
@@ -56,7 +56,7 @@ check_erofs_fsck () {
 
 check_fsverity () {
     fsverity --version >/dev/null 2>&1 || return 1
-    tmpfile=$(mktemp /var/tmp/lcfs-fsverity.XXXXXX)
+    tmpfile=$(mktemp --tmpdir lcfs-fsverity.XXXXXX)
     echo foo > $tmpfile
     fsverity enable $tmpfile >/dev/null 2>&1  || return 1
     return 0

--- a/tests/test-random-fuse.sh
+++ b/tests/test-random-fuse.sh
@@ -4,7 +4,7 @@ BINDIR="$1"
 
 set -e
 
-workdir=$(mktemp -d /var/tmp/lcfs-test.XXXXXX)
+workdir=$(mktemp --directory --tmpdir lcfs-test.XXXXXX)
 exit_cleanup() {
     umount "$workdir/mnt" &> /dev/null || true
     rm -rf -- "$workdir"

--- a/tests/test-units.sh
+++ b/tests/test-units.sh
@@ -4,7 +4,7 @@ BINDIR=$(cd "$1" && pwd)
 
 set -e
 
-workdir=$(mktemp -d /var/tmp/lcfs-test.XXXXXX)
+workdir=$(mktemp --directory --tmpdir lcfs-test.XXXXXX)
 trap 'rm -rf -- "$workdir"' EXIT
 
 . $(dirname $0)/test-lib.sh


### PR DESCRIPTION
Just upstreaming some things I ran into while I was originally packaging for nixpkgs.
Since the builds happen in a minimal sandbox it was running into non-existing directories.

The only thing I'm not sure about is the tests that involve fsverity since usually `/tmp` is a `tmpfs` and might not support it. But in that case it is probably a better idea to specifically set `$TMPDIR` for those tests rather than hardcoding `/var/tmp`