### PR TITLE
composefs-core: Drop incorrect `include`

### DIFF
--- a/rust/composefs-core/Cargo.toml
+++ b/rust/composefs-core/Cargo.toml
@@ -8,12 +8,6 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/containers/composefs"
 rust-version = "1.70.0"
 
-include = [
-    "/COPYING",
-    "/README.md",
-    "/rust/composefs-core/**",
-]
-
 [lib]
 name = "composefs"
 path = "src/lib.rs"


### PR DESCRIPTION
This is unnecessary now that we switched to a workspace; I added the licenses as symlinks into each rust crate subdirectory to ensure they're included.  I verified we don't include the C code.