### PR TITLE
info: Add missing terminator for `longopts`

### DIFF
--- a/tests/test-units.sh
+++ b/tests/test-units.sh
@@ -86,6 +86,10 @@ function test_composefs_info_measure_files () {
     cd -
 }
 
+function test_composefs_info_help () {
+    $BINDIR/composefs_info --help
+}
+
 TESTS="test_inline test_objects test_mount_digest test_composefs_info_measure_files"
 res=0
 for i in $TESTS; do

--- a/tools/composefs-info.c
+++ b/tools/composefs-info.c
@@ -407,12 +407,15 @@ int main(int argc, char **argv)
 {
 	const char *bin = argv[0];
 	int opt;
-	const struct option longopts[] = { {
-		name: "basedir",
-		has_arg: required_argument,
-		flag: NULL,
-		val: OPT_BASEDIR
-	} };
+	const struct option longopts[] = {
+		{
+			name: "basedir",
+			has_arg: required_argument,
+			flag: NULL,
+			val: OPT_BASEDIR
+		},
+		{},
+	};
 
 	while ((opt = getopt_long(argc, argv, "", longopts, NULL)) != -1) {
 		switch (opt) {


### PR DESCRIPTION
`composefs-info --help` was segfaulting for me; missing an empty terminator struct. Did I mention yet this type of thing wouldn't happen in Rust?