### PR TITLE
meson.build: Allow use as a meson subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -127,3 +127,8 @@ go_md2man = find_program('go-md2man', required : get_option('man'))
 if go_md2man.found()
   subdir('man')
 endif
+
+# For use as a subproject
+composefs_dep = declare_dependency(
+  link_with : libcomposefs,
+)


### PR DESCRIPTION
Meson superprojects need to know which build target they should link with.