### PR TITLE
mkcompose: report close() errors

### DIFF
--- a/tools/mkcomposefs.c
+++ b/tools/mkcomposefs.c
@@ -1606,6 +1606,9 @@ int main(int argc, char **argv)
 		printf("%s\n", digest_str);
 	}
 
+	if (out_file && fclose(out_file) == EOF)
+		err(EXIT_FAILURE, "close output file");
+
 	lcfs_node_unref(root);
 	return 0;
 }


### PR DESCRIPTION
if the out_file is specified, make sure it is explicitly close()d and that possible errors are reported instead of being ignored.