### PR TITLE
Minor rust lints

### DIFF
--- a/rust/composefs/src/dumpfile.rs
+++ b/rust/composefs/src/dumpfile.rs
@@ -288,9 +288,11 @@ impl<'p> Entry<'p> {
     /// Remove internal entries
     /// FIXME: This is arguably a composefs-info dump bug?
     pub fn filter_special(mut self) -> Self {
-        self.xattrs.retain(|v| match (v.key.as_bytes(), &*v.value) {
-            (b"trusted.overlay.opaque" | b"user.overlay.opaque", b"x") => false,
-            _ => true,
+        self.xattrs.retain(|v| {
+            !matches!(
+                (v.key.as_bytes(), &*v.value),
+                (b"trusted.overlay.opaque" | b"user.overlay.opaque", b"x")
+            )
         });
         self
     }

--- a/rust/composefs/src/lib.rs
+++ b/rust/composefs/src/lib.rs
@@ -12,7 +12,6 @@
 #![deny(missing_debug_implementations)]
 #![forbid(unused_must_use)]
 #![deny(unsafe_code)]
-#![cfg_attr(feature = "dox", feature(doc_cfg))]
 #![deny(clippy::dbg_macro)]
 #![deny(clippy::todo)]
 


### PR DESCRIPTION
rust: Drop unused cfg

Now checked by Rust 1.80, hooray.

Signed-off-by: Colin Walters <walters@verbum.org>

---

dumpfile: Fix clippy lint

Use `matches!` for match-evaluating-to-bool.

Signed-off-by: Colin Walters <walters@verbum.org>

---