### PR TITLE
libcomposefs: drop using "ro" option

### DIFF
--- a/libcomposefs/lcfs-mount.c
+++ b/libcomposefs/lcfs-mount.c
@@ -580,7 +580,7 @@ fallback:
 		return -ENOTSUP;
 
 	res = mount(source, target, "erofs", MS_RDONLY,
-		    image_has_acls ? "ro" : "ro,noacl");
+		    image_has_acls ? NULL : "noacl");
 	if (res < 0)
 		return -errno;
 


### PR DESCRIPTION
MS_RDONLY is enough to mount the image as read-only.