### PR TITLE
rust: Attempt to fix build on docs.rs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -141,7 +141,7 @@ jobs:
       - name: Rust (default features)
         run: cargo test
       - name: Rust (all features)
-        run: cargo test --all-features
+        run: cargo test -F v1_0_4
   clang-format:
     runs-on: ubuntu-24.04
     steps:

--- a/rust/composefs-sys/Cargo.toml
+++ b/rust/composefs-sys/Cargo.toml
@@ -9,11 +9,15 @@ build = "build.rs"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 
+[package.metadata.docs.rs]
+features = ["dox"]
+
 [package.metadata.system-deps.composefs]
 name = "composefs"
 version = "1"
 
 [features]
+dox = []
 # Depend on 1.0.4 APIs
 v1_0_4 = []
 

--- a/rust/composefs-sys/build.rs
+++ b/rust/composefs-sys/build.rs
@@ -1,4 +1,5 @@
 fn main() {
+    #[cfg(not(feature = "dox"))]
     if let Err(s) = system_deps::Config::new().probe() {
         println!("cargo:warning={s}");
         std::process::exit(1);

--- a/rust/composefs/Cargo.toml
+++ b/rust/composefs/Cargo.toml
@@ -14,6 +14,7 @@ name = "composefs"
 path = "src/lib.rs"
 
 [features]
+dox = ["composefs-sys/dox"]
 # Depend on 1.0.4 APIs
 v1_0_4 = ["composefs-sys/v1_0_4"]
 


### PR DESCRIPTION
Copy over the pattern we have in ostree to add a feature that disables our build script (which pulls in a requirement on the libcomposefs C library, which doesn't exist in the docs.rs build env) when we detect we're being built on docs.rs.