### PR TITLE
rust: Add wrapping for composefs-info dump

### DIFF
--- a/rust/composefs/Cargo.toml
+++ b/rust/composefs/Cargo.toml
@@ -24,5 +24,6 @@ libc = "0.2"
 composefs-sys = { version = "0.1.0", path = "../composefs-sys" }
 
 [dev-dependencies]
+similar-asserts = "1.5.0"
 tar = "0.4.38"
 tempfile = "3.2.0"


### PR DESCRIPTION
This allows us to deserialize from a composefs file.