### PR TITLE
Add 64bit rdev APIs

### DIFF
--- a/libcomposefs/lcfs-writer-erofs.c
+++ b/libcomposefs/lcfs-writer-erofs.c
@@ -1200,7 +1200,7 @@ static int add_overlay_whiteouts(struct lcfs_node_s *root)
 		}
 
 		lcfs_node_set_mode(child, S_IFCHR | 0644);
-		lcfs_node_set_rdev(child, 0);
+		lcfs_node_set_rdev64(child, 0);
 
 		child->inode.st_uid = root->inode.st_uid;
 		child->inode.st_gid = root->inode.st_gid;

--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -1009,12 +1009,24 @@ void lcfs_node_set_gid(struct lcfs_node_s *node, uint32_t gid)
 	node->inode.st_gid = gid;
 }
 
+// Deprecated: this truncates rdev to 32 bits
 uint32_t lcfs_node_get_rdev(struct lcfs_node_s *node)
+{
+	return (uint32_t)lcfs_node_get_rdev64(node);
+}
+
+uint64_t lcfs_node_get_rdev64(struct lcfs_node_s *node)
 {
 	return node->inode.st_rdev;
 }
 
+// Deprecated: this truncates rdev to 32 bits
 void lcfs_node_set_rdev(struct lcfs_node_s *node, uint32_t rdev)
+{
+	node->inode.st_rdev = rdev;
+}
+
+void lcfs_node_set_rdev64(struct lcfs_node_s *node, uint64_t rdev)
 {
 	node->inode.st_rdev = rdev;
 }

--- a/libcomposefs/lcfs-writer.h
+++ b/libcomposefs/lcfs-writer.h
@@ -135,8 +135,12 @@ LCFS_EXTERN uint32_t lcfs_node_get_uid(struct lcfs_node_s *node);
 LCFS_EXTERN void lcfs_node_set_uid(struct lcfs_node_s *node, uint32_t uid);
 LCFS_EXTERN uint32_t lcfs_node_get_gid(struct lcfs_node_s *node);
 LCFS_EXTERN void lcfs_node_set_gid(struct lcfs_node_s *node, uint32_t gid);
-LCFS_EXTERN uint32_t lcfs_node_get_rdev(struct lcfs_node_s *node);
-LCFS_EXTERN void lcfs_node_set_rdev(struct lcfs_node_s *node, uint32_t rdev);
+LCFS_EXTERN uint32_t lcfs_node_get_rdev(struct lcfs_node_s *node)
+	__attribute__((deprecated));
+LCFS_EXTERN uint64_t lcfs_node_get_rdev64(struct lcfs_node_s *node);
+LCFS_EXTERN void lcfs_node_set_rdev(struct lcfs_node_s *node, uint32_t rdev)
+	__attribute__((deprecated));
+LCFS_EXTERN void lcfs_node_set_rdev64(struct lcfs_node_s *node, uint64_t rdev);
 LCFS_EXTERN uint32_t lcfs_node_get_nlink(struct lcfs_node_s *node);
 LCFS_EXTERN void lcfs_node_set_nlink(struct lcfs_node_s *node, uint32_t nlink);
 LCFS_EXTERN uint64_t lcfs_node_get_size(struct lcfs_node_s *node);

--- a/tools/composefs-info.c
+++ b/tools/composefs-info.c
@@ -219,10 +219,10 @@ static void dump_node(struct lcfs_node_s *node, char *path)
 	uint64_t size = lcfs_node_get_size(target);
 
 	print_escaped(*path == 0 ? "/" : path, -1, ESCAPE_STANDARD);
-	printf(" %" PRIu64 " %s%o %u %u %u %u %" PRIi64 ".%u ", size,
+	printf(" %" PRIu64 " %s%o %u %u %u %" PRIu64 " %" PRIi64 ".%u ", size,
 	       hardlink_path != NULL ? "@" : "", lcfs_node_get_mode(target),
 	       lcfs_node_get_nlink(target), lcfs_node_get_uid(target),
-	       lcfs_node_get_gid(target), lcfs_node_get_rdev(target),
+	       lcfs_node_get_gid(target), lcfs_node_get_rdev64(target),
 	       (int64_t)mtime.tv_sec, (unsigned int)mtime.tv_nsec);
 	print_escaped_optional(hardlink_path ? hardlink_path : payload, -1,
 			       ESCAPE_LONE_DASH);

--- a/tools/mkcomposefs.c
+++ b/tools/mkcomposefs.c
@@ -512,7 +512,7 @@ static char *tree_from_dump_line(dump_info *info, const char *line, size_t line_
 	lcfs_node_set_nlink(node, nlink);
 	lcfs_node_set_uid(node, uid);
 	lcfs_node_set_gid(node, gid);
-	lcfs_node_set_rdev(node, rdev);
+	lcfs_node_set_rdev64(node, rdev);
 	lcfs_node_set_mtime(node, &mtime);
 	// Validate that symlinks are non-empty
 	if ((mode & S_IFMT) == S_IFLNK) {


### PR DESCRIPTION
I stumbled across the fact that on Linux/glibc at least `dev_t` is 64 bits, but we were truncating it to 32 bits.

Note that the type used in the `mkcomposefs` binary was already uint64_t but because C happily truncates/converts integers this was missed.