### PR TITLE
libcomposefs: detect short erofs files

### DIFF
--- a/libcomposefs/lcfs-mount.c
+++ b/libcomposefs/lcfs-mount.c
@@ -656,6 +656,8 @@ static errint_t lcfs_mount(struct lcfs_mount_state_s *state)
 	res = pread(state->fd, &header_data, HEADER_SIZE, 0);
 	if (res < 0)
 		return -errno;
+	else if (res != HEADER_SIZE)
+		return -EINVAL;
 
 	erofs_header = (struct lcfs_erofs_header_s *)header_data;
 	if (lcfs_u32_from_file(erofs_header->magic) == LCFS_EROFS_MAGIC)


### PR DESCRIPTION
When attempting to read the header of the erofs file before mounting it, we verify that the read is successful, but not that the full header has been returned.  We then proceed to access the header, which means we could be reading uninitialized memory.

Add a check to verify that we've read the full header.  If not, return -EINVAL, which is what we already return in case the header was incorrect.