### PR TITLE
all: add 'copy' mount option

### DIFF
--- a/libcomposefs/lcfs-mount.h
+++ b/libcomposefs/lcfs-mount.h
@@ -37,8 +37,9 @@ enum lcfs_mount_flags_t {
 	LCFS_MOUNT_FLAGS_READONLY = (1 << 1),
 	LCFS_MOUNT_FLAGS_IDMAP = (1 << 3),
 	LCFS_MOUNT_FLAGS_TRY_VERITY = (1 << 4),
+	LCFS_MOUNT_FLAGS_COPY = (1 << 5),
 
-	LCFS_MOUNT_FLAGS_MASK = (1 << 5) - 1,
+	LCFS_MOUNT_FLAGS_MASK = (1 << 6) - 1,
 };
 
 struct lcfs_mount_options_s {

--- a/tools/mountcomposefs.c
+++ b/tools/mountcomposefs.c
@@ -123,6 +123,7 @@ int main(int argc, char **argv)
 	bool opt_verity = false;
 	bool opt_tryverity = false;
 	bool opt_ro = false;
+	bool opt_copy = false;
 	int opt, fd, res, userns_fd;
 
 	while ((opt = getopt(argc, argv, "ht:o:")) != -1) {
@@ -198,6 +199,8 @@ int main(int argc, char **argv)
 			opt_ro = false;
 		} else if (strcmp("ro", key) == 0) {
 			opt_ro = true;
+		} else if (strcmp("copy", key) == 0) {
+			opt_copy = true;
 		} else {
 			errx(EXIT_FAILURE, "Unsupported option %s\n", key);
 		}
@@ -248,6 +251,8 @@ int main(int argc, char **argv)
 		options.flags |= LCFS_MOUNT_FLAGS_TRY_VERITY;
 	if (opt_ro)
 		options.flags |= LCFS_MOUNT_FLAGS_READONLY;
+	if (opt_copy)
+		options.flags |= LCFS_MOUNT_FLAGS_COPY;
 
 	if (opt_idmap != NULL) {
 		userns_fd = open(opt_idmap, O_RDONLY | O_CLOEXEC | O_NOCTTY);


### PR DESCRIPTION
This copies the content of the named composefs image into a sealed memfd and mounts that, instead of using the underlying file.

The main benefit here is that the underlying filesystem isn't pinned by having one of its files used as the basis of the loopback device.  This is useful if you want to embed a composefs into an initramfs, for example.

There are also integrity benefits.  Without this option, the fsverity of the file is verified at mount time, but nothing stops the file from being modified after the fact.  With the copy option, we measure and compare the fsverity signature after copying into and sealing the memfd.

Right now this is implemented as a straight copy, but we may also add support for decompression at some point.  The erofs images compress reasonably well using general-purpose compression algorithms: a 52MB image of /usr on my system compresses down to 14MB with zstd and 13MB with xz.