### PR TITLE
A few cleanups around symlinks

### DIFF
--- a/libcomposefs/lcfs-writer-erofs.c
+++ b/libcomposefs/lcfs-writer-erofs.c
@@ -1746,7 +1746,7 @@ static struct lcfs_node_s *lcfs_build_node_from_image(struct lcfs_image_data *da
 
 		memcpy(name_buf, tail_data, file_size);
 		name_buf[file_size] = 0;
-		if (lcfs_node_set_payload(node, name_buf) < 0)
+		if (lcfs_node_set_symlink_payload(node, name_buf) < 0)
 			return NULL;
 
 	} else if (type == S_IFREG && file_size != 0 && erofs_inode_is_flat(cino)) {

--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -989,6 +989,15 @@ void lcfs_node_set_mode(struct lcfs_node_s *node, uint32_t mode)
 	node->inode.st_mode = mode;
 }
 
+int lcfs_node_try_set_mode(struct lcfs_node_s *node, uint32_t mode)
+{
+	if (lcfs_validate_mode(mode) < 0) {
+		return -1;
+	}
+	node->inode.st_mode = mode;
+	return 0;
+}
+
 uint32_t lcfs_node_get_uid(struct lcfs_node_s *node)
 {
 	return node->inode.st_uid;

--- a/libcomposefs/lcfs-writer.h
+++ b/libcomposefs/lcfs-writer.h
@@ -108,6 +108,8 @@ LCFS_EXTERN const char *lcfs_node_get_xattr_name(struct lcfs_node_s *node,
 						 size_t index);
 
 LCFS_EXTERN int lcfs_node_set_payload(struct lcfs_node_s *node, const char *payload);
+LCFS_EXTERN int lcfs_node_set_symlink_payload(struct lcfs_node_s *node,
+					      const char *payload);
 LCFS_EXTERN const char *lcfs_node_get_payload(struct lcfs_node_s *node);
 
 LCFS_EXTERN int lcfs_node_set_content(struct lcfs_node_s *node,

--- a/libcomposefs/lcfs-writer.h
+++ b/libcomposefs/lcfs-writer.h
@@ -131,6 +131,7 @@ LCFS_EXTERN struct lcfs_node_s *lcfs_node_get_hardlink_target(struct lcfs_node_s
 LCFS_EXTERN bool lcfs_node_dirp(struct lcfs_node_s *node);
 LCFS_EXTERN uint32_t lcfs_node_get_mode(struct lcfs_node_s *node);
 LCFS_EXTERN void lcfs_node_set_mode(struct lcfs_node_s *node, uint32_t mode);
+LCFS_EXTERN int lcfs_node_try_set_mode(struct lcfs_node_s *node, uint32_t mode);
 LCFS_EXTERN uint32_t lcfs_node_get_uid(struct lcfs_node_s *node);
 LCFS_EXTERN void lcfs_node_set_uid(struct lcfs_node_s *node, uint32_t uid);
 LCFS_EXTERN uint32_t lcfs_node_get_gid(struct lcfs_node_s *node);

--- a/tools/mkcomposefs.c
+++ b/tools/mkcomposefs.c
@@ -437,7 +437,9 @@ static char *tree_from_dump_line(dump_info *info, const char *line, size_t line_
 	if (node == NULL) {
 		oom();
 	}
-	lcfs_node_set_mode(node, mode);
+	if (lcfs_node_try_set_mode(node, mode) < 0) {
+		return make_error("Invalid mode %o", (unsigned int)mode);
+	}
 
 	err = tree_add_node(info, path, node);
 	if (err)

--- a/tools/mkcomposefs.c
+++ b/tools/mkcomposefs.c
@@ -507,7 +507,6 @@ static char *tree_from_dump_line(dump_info *info, const char *line, size_t line_
 	if (digest == NULL && err)
 		return err;
 
-	lcfs_node_set_mode(node, mode);
 	lcfs_node_set_size(node, size);
 	lcfs_node_set_nlink(node, nlink);
 	lcfs_node_set_uid(node, uid);

--- a/tools/mkcomposefs.c
+++ b/tools/mkcomposefs.c
@@ -440,6 +440,7 @@ static char *tree_from_dump_line(dump_info *info, const char *line, size_t line_
 	if (lcfs_node_try_set_mode(node, mode) < 0) {
 		return make_error("Invalid mode %o", (unsigned int)mode);
 	}
+	unsigned int type = mode & S_IFMT;
 
 	err = tree_add_node(info, path, node);
 	if (err)
@@ -509,20 +510,22 @@ static char *tree_from_dump_line(dump_info *info, const char *line, size_t line_
 	if (digest == NULL && err)
 		return err;
 
-	lcfs_node_set_size(node, size);
+	if (type != S_IFLNK)
+		lcfs_node_set_size(node, size);
 	lcfs_node_set_nlink(node, nlink);
 	lcfs_node_set_uid(node, uid);
 	lcfs_node_set_gid(node, gid);
 	lcfs_node_set_rdev64(node, rdev);
 	lcfs_node_set_mtime(node, &mtime);
 	// Validate that symlinks are non-empty
-	if ((mode & S_IFMT) == S_IFLNK) {
-		if (payload == NULL) {
-			return make_error("Invalid empty symlink");
+	if (type == S_IFLNK) {
+		if (lcfs_node_set_symlink_payload(node, payload) < 0) {
+			return make_error("Invalid symlink");
 		}
+	} else {
+		if (lcfs_node_set_payload(node, payload) < 0)
+			return make_error("Invalid payload");
 	}
-	if (lcfs_node_set_payload(node, payload) < 0)
-		return make_error("Invalid payload");
 	if (content) {
 		ret = lcfs_node_set_content(node, (uint8_t *)content, size);
 		if (ret < 0)


### PR DESCRIPTION
mkcomposefs: Drop duplicate invocation of lcfs_node_set_mode()

Just noticed this while I was reading the code for other reasons.

Signed-off-by: Colin Walters <walters@verbum.org>

---

Add fallible lcfs_node_try_set_mode()

Previously I added code to validate this but it happened much
later. The mode (type) of a file is a very fundamental property
and we should constrain its state as early as possible.

Signed-off-by: Colin Walters <walters@verbum.org>

---

Add lcfs_node_set_symlink_payload

Historically we accept any arbitrary data in the dumpfile
for the file size for symlink, and end up ignoring it
ultimately when we write the EROFS. However previously
it was pretty confusing as the in-memory node data
could have a bogus size.

Add an API and use it both in the mkcomposefs path *and*
in the "reread from EROFS path" to perform more consistent
validation for symlink targets. This just wraps the
previous `lcfs_node_set_payload()` API, inheriting its
checks for length.

Signed-off-by: Colin Walters <walters@verbum.org>

---