### PR TITLE
tests: Move sha verification after other checks

### DIFF
--- a/tests/test-checksums.sh
+++ b/tests/test-checksums.sh
@@ -43,11 +43,6 @@ for format in erofs ; do
             fsck.erofs $tmpfile
         fi
 
-        if [ $SHA != $EXPECTED_SHA ]; then
-            echo Invalid $format checksum of file generated from $file: $SHA, expected $EXPECTED_SHA
-            exit 1
-        fi
-
         # Ensure dump reproduces the same file
         ${VALGRIND_PREFIX} ${BINDIR}/composefs-dump $tmpfile $tmpfile2
         if ! cmp $tmpfile $tmpfile2; then
@@ -60,5 +55,11 @@ for format in erofs ; do
             echo Dump is not reproducible via composefs-info dump
             exit 1
         fi
+
+        if [ $SHA != $EXPECTED_SHA ]; then
+            echo Invalid $format checksum of file generated from $file: $SHA, expected $EXPECTED_SHA
+            exit 1
+        fi
+        echo "ok $file"
     done
 done


### PR DESCRIPTION
When testing out changes to a dumpfile, today the sha check will always fail first if I don't go and change the expected value, but most of the time what I want to know is whether or not it passes the *other* tests at least.

Move the checksum verification last, and also while we're here print an "ok" value.