### PR TITLE
ci: update deprecated {up,down}load-artifact@v2 to v4

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Capture build
         run: DESTDIR=$(pwd)/instroot meson install -C build && tar -C instroot -czf composefs.tar .
       - name: Upload binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: composefs.tar
           path: composefs.tar
@@ -67,7 +67,7 @@ jobs:
       - name: Capture build
         run: DESTDIR=$(pwd)/instroot meson install -C build && tar -C instroot -czf composefs.tar .
       - name: Upload binary
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: composefs-noasan.tar
           path: composefs.tar
@@ -148,7 +148,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Download
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: composefs.tar
       - run: sudo tar -C / -xvf composefs.tar
@@ -162,7 +162,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Download
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: composefs-noasan.tar
       - run: sudo tar -C / -xvf composefs.tar


### PR DESCRIPTION
https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

Looks like this has outright started failing now, see:

https://github.com/containers/composefs/actions/runs/10793804365/job/29936602526#step:1:24
https://github.com/containers/composefs/actions/runs/10793804365/job/29936603900#step:1:24

Signed-off-by: John Eckersberg <jeckersb@redhat.com>
