### PR TITLE
ci: Drop "with meson" from description

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Test with meson
+name: Test
 
 on: [push, pull_request]
 


### PR DESCRIPTION
It's now the only buildsystem.