### PR TITLE
rust: Another attempt to fix docs.rs build

### DIFF
--- a/rust/composefs-sys/Cargo.toml
+++ b/rust/composefs-sys/Cargo.toml
@@ -10,14 +10,15 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [package.metadata.docs.rs]
-features = ["dox"]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
 
 [package.metadata.system-deps.composefs]
 name = "composefs"
 version = "1"
 
 [features]
-dox = []
 # Depend on 1.0.4 APIs
 v1_0_4 = []
 

--- a/rust/composefs-sys/build.rs
+++ b/rust/composefs-sys/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    #[cfg(not(feature = "dox"))]
+    #[cfg(not(docsrs))]
     if let Err(s) = system_deps::Config::new().probe() {
         println!("cargo:warning={s}");
         std::process::exit(1);

--- a/rust/composefs/Cargo.toml
+++ b/rust/composefs/Cargo.toml
@@ -9,12 +9,16 @@ repository = "https://github.com/containers/composefs"
 rust-version = "1.70.0"
 readme = "README.md"
 
+[package.metadata.docs.rs]
+all-features = true
+rustc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--generate-link-to-definition"]
+
 [lib]
 name = "composefs"
 path = "src/lib.rs"
 
 [features]
-dox = ["composefs-sys/dox"]
 # Depend on 1.0.4 APIs
 v1_0_4 = ["composefs-sys/v1_0_4"]
 


### PR DESCRIPTION
The build on docs.rs is still failing due to missing the C library. The standard thing to do here is just not to look for it when building docs.

This time I copied the setup from gtk4-rs; the newer pattern here seems to be directly using `rustc-args` and `rustdoc-args` instead of exposing a `dox` feature.

What I believe I missed in the last attempt was the copy of `package.metadata.docs.rs` in the `composefs`
crate.