### PR TITLE
rust: Release 0.1.2

### DIFF
--- a/rust/composefs-sys/Cargo.toml
+++ b/rust/composefs-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "composefs-sys"
 description = "Rust library wrapping the libcomposefs C library"
 keywords = ["composefs"]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 links = "composefs"
 build = "build.rs"

--- a/rust/composefs/Cargo.toml
+++ b/rust/composefs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "composefs"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Rust library for the composefs filesystem"
 keywords = ["composefs"]


### PR DESCRIPTION
Mainly just to hopefully fix the build on docs.rs finally.