### PR TITLE
Expose optimized fsverity interface to Rust

### DIFF
--- a/rust/composefs-sys/src/lib.rs
+++ b/rust/composefs-sys/src/lib.rs
@@ -8,6 +8,7 @@ extern "C" {
         digest: *mut u8,
         fd: std::os::raw::c_int,
     ) -> std::os::raw::c_int;
+    pub fn lcfs_fd_get_fsverity(digest: *mut u8, fd: std::os::raw::c_int) -> std::os::raw::c_int;
     #[cfg(feature = "v1_0_4")]
     pub fn lcfs_fd_enable_fsverity(fd: std::os::raw::c_int) -> std::os::raw::c_int;
 }
@@ -42,13 +43,12 @@ mod tests {
 
     #[test]
     fn test_digest() -> Result<()> {
-        unsafe {
+        for f in [lcfs_compute_fsverity_from_fd, lcfs_fd_get_fsverity] {
             let mut tf = tempfile::tempfile()?;
             tf.write_all(b"hello world")?;
             let mut buf = [0u8; LCFS_SHA256_DIGEST_LEN];
             tf.seek(std::io::SeekFrom::Start(0))?;
-            let r = lcfs_compute_fsverity_from_fd(buf.as_mut_ptr(), tf.as_raw_fd());
-            assert_eq!(r, 0);
+            unsafe { f(buf.as_mut_ptr(), tf.as_raw_fd()) };
             assert_eq!(
                 buf,
                 [
@@ -56,7 +56,7 @@ mod tests {
                     249, 37, 177, 227, 80, 118, 216, 199, 213, 245, 99, 98, 186, 100
                 ]
             );
-            Ok(())
         }
+        Ok(())
     }
 }

--- a/rust/composefs/src/fsverity.rs
+++ b/rust/composefs/src/fsverity.rs
@@ -23,10 +23,11 @@ impl Digest {
 }
 
 /// Compute the composefs fsverity digest from the provided file descriptor.
+/// If fsverity is already enabled, this will return the digest computed by the kernel.
 #[allow(unsafe_code)]
 pub fn fsverity_digest_from_fd(fd: BorrowedFd, digest: &mut Digest) -> std::io::Result<()> {
     unsafe {
-        map_result(composefs_sys::lcfs_compute_fsverity_from_fd(
+        map_result(composefs_sys::lcfs_fd_get_fsverity(
             digest.0.as_mut_ptr(),
             fd.as_raw_fd(),
         ))


### PR DESCRIPTION
On the C side we have two functions:

- `lcfs_compute_fsverity_from_fd`
- `lfs_fd_get_fsverity`

The first is currently defined to operate purely in memory. The second checks if fsverity is already enabled on the fd, and if so just asks the kernel for it; falling back to the first case otherwise.

I'm actually not entirely sure if we really need both; it seems like if we have a fd we'd basically always want to use the kernel code if possible.

Out of conservatism for now, expose both on the composefs-sys Rust binding side. But on the high level interface just change what we're using to be backed by `lcfs_fd_get_fsverity()`.

If someone really cares later of course we can add sugar for the pure compute path in the high level Rust API too.