### PR TITLE
meson.build: raise used C standard to C11

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
   'c',
   version : '1.0.6',
   default_options : [
-    'c_std=c99',
+    'c_std=c11',
     'warning_level=1',
   ],
 )


### PR DESCRIPTION
Some C11 features have been used, but meson.build still specifies c_std=c99, leading to errors on Clang compiler.

Fixes: https://github.com/containers/composefs/issues/364