### PR TITLE
libcomposefs: include linux/limits.h to satisfy usage of XATTR_NAME_MAX

### DIFF
--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -30,6 +30,7 @@
 #include <errno.h>
 #include <string.h>
 #include <linux/fsverity.h>
+#include <linux/limits.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>


### PR DESCRIPTION
XATTR_NAME_MAX is defined in linux/limits.h, but leaked by glibc since its sys/param.h includes the former header, which is not true on musl and leads to errors like:

```
	../libcomposefs/lcfs-writer.c:1688:16: error: use of undeclared identifier 'XATTR_NAME_MAX'
	 1688 |         if (namelen > XATTR_NAME_MAX) {
```

Include linux/limits.h explicitly to build properly on musl.