### PR TITLE
Add a libcomposefs-internal

### DIFF
--- a/libcomposefs/lcfs-utils.c
+++ b/libcomposefs/lcfs-utils.c
@@ -31,3 +31,30 @@ void digest_to_string(const uint8_t *csum, char *buf)
 	}
 	buf[j] = '\0';
 }
+
+int digest_to_raw(const char *digest, uint8_t *raw, int max_size)
+{
+	int size = 0;
+
+	while (*digest) {
+		char c1, c2;
+		int n1, n2;
+
+		if (size >= max_size)
+			return -1;
+
+		c1 = *digest++;
+		n1 = hexdigit(c1);
+		if (n1 < 0)
+			return -1;
+
+		c2 = *digest++;
+		n2 = hexdigit(c2);
+		if (n2 < 0)
+			return -1;
+
+		raw[size++] = (n1 & 0xf) << 4 | (n2 & 0xf);
+	}
+
+	return size;
+}

--- a/libcomposefs/lcfs-utils.c
+++ b/libcomposefs/lcfs-utils.c
@@ -1,0 +1,33 @@
+/* lcfs
+   This file is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as
+   published by the Free Software Foundation; either version 2.1 of the
+   License, or (at your option) any later version.
+
+   This file is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
+
+#define _GNU_SOURCE
+
+#include "config.h"
+
+#include "lcfs-utils.h"
+#include "lcfs-writer.h"
+
+void digest_to_string(const uint8_t *csum, char *buf)
+{
+	static const char hexchars[] = "0123456789abcdef";
+	uint32_t i, j;
+
+	for (i = 0, j = 0; i < LCFS_DIGEST_SIZE; i++, j += 2) {
+		uint8_t byte = csum[i];
+		buf[j] = hexchars[byte >> 4];
+		buf[j + 1] = hexchars[byte & 0xF];
+	}
+	buf[j] = '\0';
+}

--- a/libcomposefs/lcfs-utils.h
+++ b/libcomposefs/lcfs-utils.h
@@ -70,34 +70,8 @@ static inline int hexdigit(char c)
 	return -1;
 }
 
-static inline int digest_to_raw(const char *digest, uint8_t *raw, int max_size)
-{
-	int size = 0;
-
-	while (*digest) {
-		char c1, c2;
-		int n1, n2;
-
-		if (size >= max_size)
-			return -1;
-
-		c1 = *digest++;
-		n1 = hexdigit(c1);
-		if (n1 < 0)
-			return -1;
-
-		c2 = *digest++;
-		n2 = hexdigit(c2);
-		if (n2 < 0)
-			return -1;
-
-		raw[size++] = (n1 & 0xf) << 4 | (n2 & 0xf);
-	}
-
-	return size;
-}
-
 void digest_to_string(const uint8_t *csum, char *buf);
+int digest_to_raw(const char *digest, uint8_t *raw, int max_size);
 
 static inline char *str_join(const char *a, const char *b)
 {

--- a/libcomposefs/lcfs-utils.h
+++ b/libcomposefs/lcfs-utils.h
@@ -19,6 +19,8 @@
 
 #include <assert.h>
 #include <stdlib.h>
+#include <stdint.h>
+#include <stdbool.h>
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>
@@ -94,6 +96,8 @@ static inline int digest_to_raw(const char *digest, uint8_t *raw, int max_size)
 
 	return size;
 }
+
+void digest_to_string(const uint8_t *csum, char *buf);
 
 static inline char *str_join(const char *a, const char *b)
 {

--- a/libcomposefs/meson.build
+++ b/libcomposefs/meson.build
@@ -1,3 +1,15 @@
+internal_source_files = files([
+  'lcfs-utils.h',
+  'lcfs-utils.c',
+])
+
+libcomposefs_internal = static_library('composefs-internal',
+  internal_source_files,
+  c_args : composefs_hash_cflags + hidden_visibility_cflags,
+  include_directories : config_inc,
+  install : false,
+)
+
 source_files = files([
   'bitrotate.h',
   'erofs_fs.h',
@@ -12,7 +24,6 @@ source_files = files([
   'lcfs-writer-erofs.c',
   'lcfs-writer.c',
   'lcfs-writer.h',
-  'lcfs-utils.h',
   'lcfs-mount.c',
   'lcfs-mount.h',
   'xalloc-oversized.h',
@@ -22,6 +33,7 @@ libcomposefs = both_libraries('composefs',
   source_files,
   c_args : composefs_hash_cflags + hidden_visibility_cflags,
   dependencies : libcrypto_dep,
+  link_with: libcomposefs_internal,
   version : libversion,
   soversion : soversion,
   include_directories : config_inc,

--- a/tools/composefs-info.c
+++ b/tools/composefs-info.c
@@ -154,19 +154,6 @@ static void print_node_handler(struct lcfs_node_s *node, void *data)
 	print_node(node, "");
 }
 
-static void digest_to_string(const uint8_t *csum, char *buf)
-{
-	static const char hexchars[] = "0123456789abcdef";
-	uint32_t i, j;
-
-	for (i = 0, j = 0; i < LCFS_DIGEST_SIZE; i++, j += 2) {
-		uint8_t byte = csum[i];
-		buf[j] = hexchars[byte >> 4];
-		buf[j + 1] = hexchars[byte & 0xF];
-	}
-	buf[j] = '\0';
-}
-
 static char *node_build_path(struct lcfs_node_s *node)
 {
 	size_t pathlen = 0;

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -5,12 +5,14 @@ thread_dep = dependency('threads')
 executable('mkcomposefs',
     'mkcomposefs.c',
     dependencies : [libcomposefs_dep, thread_dep],
+    link_with: [libcomposefs_internal],
     install : true,
 )
 
 executable('mount.composefs',
     'mountcomposefs.c',
     dependencies : [libcomposefs_dep],
+    link_with: [libcomposefs_internal],
     install : true,
     install_dir : get_option('sbindir'),
 )
@@ -18,12 +20,14 @@ executable('mount.composefs',
 executable('composefs-info',
     ['composefs-info.c', '../libcomposefs/hash.c'],
     c_args : composefs_hash_cflags,
+    link_with: [libcomposefs_internal],
     dependencies : [libcomposefs_dep],
     install : true,
 )
 
 executable('composefs-dump',
     'composefs-dump.c',
+    link_with: [libcomposefs_internal],
     dependencies : [libcomposefs_dep],
     install : false,
 )

--- a/tools/mkcomposefs.c
+++ b/tools/mkcomposefs.c
@@ -1428,19 +1428,6 @@ static int fill_store(const int thread_count, struct lcfs_node_s *node,
 	return ret;
 }
 
-static void digest_to_string(const uint8_t *csum, char *buf)
-{
-	static const char hexchars[] = "0123456789abcdef";
-	uint32_t i, j;
-
-	for (i = 0, j = 0; i < LCFS_DIGEST_SIZE; i++, j += 2) {
-		uint8_t byte = csum[i];
-		buf[j] = hexchars[byte >> 4];
-		buf[j + 1] = hexchars[byte & 0xF];
-	}
-	buf[j] = '\0';
-}
-
 static int get_cpu_count(void)
 {
 	cpu_set_t set;


### PR DESCRIPTION
I came across the fact that we had two copy-paste implementations
of converting a binary digest to hex.
    
Deduplicate with an internal shared library.

NOTE: I don't speak meson fluently so please check if I messed
something up there.