### PR TITLE
rust: Enable v1_0_4 feature by default

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -172,8 +172,8 @@ jobs:
           key: "rust-main"
       - name: Rust (default features)
         run: cargo test
-      - name: Rust (all features)
-        run: cargo test -F v1_0_4
+      - name: Rust (no features)
+        run: cargo test --no-default-features
   distcheck:
     runs-on: ubuntu-latest
     steps:

--- a/rust/composefs/Cargo.toml
+++ b/rust/composefs/Cargo.toml
@@ -21,6 +21,7 @@ path = "src/lib.rs"
 [features]
 # Depend on 1.0.4 APIs
 v1_0_4 = ["composefs-sys/v1_0_4"]
+default = ["v1_0_4"]
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
It's been out long enough I think we can do this.
Motivated by wanting to write some code using
it in an example and it's apparently not possible
to use off-by-default features in examples.