### PR TITLE
internal: Rewrite byteswapping macros

### DIFF
--- a/libcomposefs/lcfs-internal.h
+++ b/libcomposefs/lcfs-internal.h
@@ -75,47 +75,13 @@ typedef int errint_t;
 
 #define LCFS_MAX_NAME_LENGTH 255 /* max len of file name excluding NULL */
 
-#define lcfs_u16_to_file(v)                                                    \
-	({                                                                     \
-		_Static_assert(sizeof(v) == sizeof(uint16_t),                  \
-			       "Size of v is not equal to size of uint16_t");  \
-		htole16(v);                                                    \
-	})
-
-#define lcfs_u32_to_file(v)                                                    \
-	({                                                                     \
-		_Static_assert(sizeof(v) == sizeof(uint32_t),                  \
-			       "Size of v is not equal to size of uint32_t");  \
-		htole32(v);                                                    \
-	})
-
-#define lcfs_u64_to_file(v)                                                    \
-	({                                                                     \
-		_Static_assert(sizeof(v) == sizeof(uint64_t),                  \
-			       "Size of v is not equal to size of uint64_t");  \
-		htole64(v);                                                    \
-	})
-
-#define lcfs_u16_from_file(v)                                                  \
-	({                                                                     \
-		_Static_assert(sizeof(v) == sizeof(uint16_t),                  \
-			       "Size of v is not equal to size of uint16_t");  \
-		le16toh(v);                                                    \
-	})
-
-#define lcfs_u32_from_file(v)                                                  \
-	({                                                                     \
-		_Static_assert(sizeof(v) == sizeof(uint32_t),                  \
-			       "Size of v is not equal to size of uint32_t");  \
-		le32toh(v);                                                    \
-	})
-
-#define lcfs_u64_from_file(v)                                                  \
-	({                                                                     \
-		_Static_assert(sizeof(v) == sizeof(uint64_t),                  \
-			       "Size of v is not equal to size of uint64_t");  \
-		le64toh(v);                                                    \
-	})
+/* Alias macros for the generic conversions; we can drop these at some point */
+#define lcfs_u16_to_file(v) (htole16(v))
+#define lcfs_u32_to_file(v) (htole32(v))
+#define lcfs_u64_to_file(v) (htole64(v))
+#define lcfs_u16_from_file(v) (le16toh(v))
+#define lcfs_u32_from_file(v) (le32toh(v))
+#define lcfs_u64_from_file(v) (le64toh(v))
 
 /* In memory representation used to build the file.  */
 

--- a/libcomposefs/lcfs-writer-erofs.c
+++ b/libcomposefs/lcfs-writer-erofs.c
@@ -948,7 +948,7 @@ static int write_erofs_inode_data(struct lcfs_ctx_s *ctx, struct lcfs_node_s *no
 		i.i_ino = lcfs_u32_to_file(node->inode_num);
 		i.i_uid = lcfs_u32_to_file(node->inode.st_uid);
 		i.i_gid = lcfs_u32_to_file(node->inode.st_gid);
-		i.i_mtime = lcfs_u64_to_file(node->inode.st_mtim_sec);
+		i.i_mtime = lcfs_u64_to_file((uint64_t)node->inode.st_mtim_sec);
 		i.i_mtime_nsec = lcfs_u32_to_file(node->inode.st_mtim_nsec);
 
 		if (type == S_IFDIR) {
@@ -1398,13 +1398,13 @@ int lcfs_write_erofs_to(struct lcfs_ctx_s *ctx)
 	struct lcfs_ctx_erofs_s *ctx_erofs = (struct lcfs_ctx_erofs_s *)ctx;
 	struct lcfs_node_s *root;
 	struct lcfs_erofs_header_s header = {
-		.magic = lcfs_u32_to_file(LCFS_EROFS_MAGIC),
-		.version = lcfs_u32_to_file(LCFS_EROFS_VERSION),
+		.magic = lcfs_u32_to_file(((uint32_t)LCFS_EROFS_MAGIC)),
+		.version = lcfs_u32_to_file(((uint32_t)LCFS_EROFS_VERSION)),
 		.composefs_version = lcfs_u32_to_file(ctx->options->version),
 	};
 	uint32_t header_flags;
 	struct erofs_super_block superblock = {
-		.magic = lcfs_u32_to_file(EROFS_SUPER_MAGIC_V1),
+		.magic = lcfs_u32_to_file(((uint32_t)EROFS_SUPER_MAGIC_V1)),
 		.blkszbits = EROFS_BLKSIZ_BITS,
 	};
 	int ret = 0;
@@ -1447,11 +1447,12 @@ int lcfs_write_erofs_to(struct lcfs_ctx_s *ctx)
 	if (ret < 0)
 		return ret;
 
-	superblock.feature_compat = lcfs_u32_to_file(
-		EROFS_FEATURE_COMPAT_MTIME | EROFS_FEATURE_COMPAT_XATTR_FILTER);
+	superblock.feature_compat =
+		lcfs_u32_to_file((uint32_t)(EROFS_FEATURE_COMPAT_MTIME |
+					    EROFS_FEATURE_COMPAT_XATTR_FILTER));
 	superblock.inos = lcfs_u64_to_file(ctx->num_inodes);
 
-	superblock.build_time = lcfs_u64_to_file(ctx->min_mtim_sec);
+	superblock.build_time = lcfs_u64_to_file((uint64_t)ctx->min_mtim_sec);
 	superblock.build_time_nsec = lcfs_u32_to_file(ctx->min_mtim_nsec);
 
 	/* metadata is stored directly after superblock */


### PR DESCRIPTION
The real motivation here is to rewrite the code in order to complete the relicensing, because the person who last touched this didn't respond.

And in general, using `_Generic` here cleans things up anyways.