### PR TITLE
tests: Add a flow for integration test with fsverity enabled

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -156,8 +156,8 @@ jobs:
       - run: sudo apt-get update -y
       - name: Install erofs kmod
         run: sudo apt install linux-modules-extra-$(uname -r)
-      - name: Install sanitizer dependencies
-        run: sudo apt install libasan6 libubsan1
+      - name: Install dependencies
+        run: sudo apt install libasan6 libubsan1 fsverity
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Download
@@ -167,6 +167,8 @@ jobs:
       - run: sudo tar -C / -xvf composefs.tar
       - name: Integration tests
         run: sudo ./tests/integration.sh
+      - name: Integration tests (fsverity required)
+        run: sudo env WITH_TEMP_VERITY=1 unshare -m ./tests/integration.sh
   rust:
     needs: build-noasan
     runs-on: ubuntu-latest

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -44,6 +44,22 @@ run_test() {
 
 run_test /usr/bin "--no-nlink"
 
+check_fsverity () {
+    fsverity --version >/dev/null 2>&1 || return 1
+    tmpfile=$(mktemp --tmpdir lcfs-fsverity.XXXXXX)
+    echo foo > $tmpfile
+    fsverity enable $tmpfile >/dev/null 2>&1  || return 1
+    return 0
+}
+
+echo "fsverity test" > ${cfsroot}/test-fsverity
+if fsverity enable ${cfsroot}/test-fsverity; then
+    echo "fsverity is supported"
+else
+    echo "fsverity unsupported"
+fi
+rm -f ${cfsroot}/test-fsverity
+
 # Don't create whiteouts, as they depend on a very recent kernel to work at all
 $orig/tests/gendir --privileged --nowhiteout ${cfsroot}/tmp/rootfs
 # nlink doesn't work for the toplevel dir in composefs, because that is from overlayfs, not erofs


### PR DESCRIPTION
integration: Clearly show in logs if we tested with fsverity

---

tests: Add a flow for integration test with fsverity enabled

This was an obvious CI coverage gap.

Signed-off-by: Colin Walters <walters@verbum.org>

---