### PR TITLE
MAINTAINERS.md: New file

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,11 @@
+# Maintainers
+
+The current Maintainers Group for the composefs Project consists of (in last name alphabetical order):
+
+| Name              | GitHub ID                                      | Employer        | Responsibilities |
+| ----              | ----                                           | ----            | ----             |
+| Alexander Larsson | [alexl](https://github.com/alexlarsson)        | Red Hat         | Approver         |
+| Jan Lübbe         | [jluebbe](https://github.com/jluebbe)          | @pengutronix    | Approver         |
+| Giuseppe Scrivano | [giuseppe](https://github.com/giuseppe)        | Red Hat         | Approver         |
+| Erik Sjölund      | [eriksjolund](https://github.com/eriksjolund)  | Independent     | Approver         |
+| Colin Walters     | [cgwalters](https://github.com/cgwalters)      | Red Hat         | Approver         |


### PR DESCRIPTION
This list is intentionally a strawman proposal; I listed the current 4 top contributors (as computed by GH).

It obviously overlaps with the GH commit access, but that's something tools exist to synchronize.

Motivated by matching community standards.