### PR TITLE
lib: Add lcfs_fd_measure_fsverity

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -141,7 +141,7 @@ jobs:
             ./hacking/installdeps.sh
             meson setup build --werror
             meson compile -C build
-            meson test -C build --timeout-multiplier 10
+            env CFS_TEST_ARCH_EMULATION=${{ matrix.arch }} meson test -C build --timeout-multiplier 10
       - name: Upload log
         uses: actions/upload-artifact@v4
         if: always()

--- a/libcomposefs/lcfs-writer.c
+++ b/libcomposefs/lcfs-writer.c
@@ -576,6 +576,10 @@ int lcfs_fd_measure_fsverity(uint8_t *digest, int fd)
 	fsv->digest_size = MAX_DIGEST_SIZE;
 	int res = ioctl(fd, FS_IOC_MEASURE_VERITY, fsv);
 	if (res == -1) {
+		if (errno == ENODATA || errno == EOPNOTSUPP || errno == ENOTTY) {
+			// Canonicalize errno
+			errno = ENOVERITY;
+		}
 		return -errno;
 	}
 	// The file has fsverity enabled, but with an unexpected different algorithm (e.g. sha512).

--- a/libcomposefs/lcfs-writer.h
+++ b/libcomposefs/lcfs-writer.h
@@ -182,6 +182,7 @@ LCFS_EXTERN int lcfs_compute_fsverity_from_content(uint8_t *digest, void *file,
 LCFS_EXTERN int lcfs_compute_fsverity_from_fd(uint8_t *digest, int fd);
 LCFS_EXTERN int lcfs_compute_fsverity_from_data(uint8_t *digest, uint8_t *data,
 						size_t data_len);
+LCFS_EXTERN int lcfs_fd_measure_fsverity(uint8_t *digest, int fd);
 LCFS_EXTERN int lcfs_fd_get_fsverity(uint8_t *digest, int fd);
 
 LCFS_EXTERN int lcfs_node_set_from_content(struct lcfs_node_s *node, int dirfd,

--- a/tests/test-lcfs.c
+++ b/tests/test-lcfs.c
@@ -2,6 +2,7 @@
 #define _GNU_SOURCE
 
 #include "lcfs-writer.h"
+#include "lcfs-mount.h"
 #include <assert.h>
 #include <unistd.h>
 #include <errno.h>
@@ -84,8 +85,10 @@ static void test_no_verity(void)
 	assert(tmpfd > 0);
 
 	uint8_t digest[LCFS_DIGEST_SIZE];
-	int r = lcfs_fd_require_fsverity(digest, tmpfd);
+	int r = lcfs_fd_measure_fsverity(digest, tmpfd);
+	int errsv = errno;
 	assert(r != 0);
+	assert(errsv == ENOVERITY);
 	close(tmpfd);
 }
 

--- a/tests/test-lcfs.c
+++ b/tests/test-lcfs.c
@@ -88,7 +88,9 @@ static void test_no_verity(void)
 	int r = lcfs_fd_measure_fsverity(digest, tmpfd);
 	int errsv = errno;
 	assert(r != 0);
-	assert(errsv == ENOVERITY);
+	// We may get ENOSYS from qemu userspace emulation not implementing the ioctl
+	if (getenv("CFS_TEST_ARCH_EMULATION") == NULL)
+		assert(errsv == ENOVERITY);
 	close(tmpfd);
 }
 

--- a/tests/test-lcfs.c
+++ b/tests/test-lcfs.c
@@ -3,6 +3,7 @@
 
 #include "lcfs-writer.h"
 #include <assert.h>
+#include <unistd.h>
 #include <errno.h>
 
 static inline void lcfs_node_unrefp(struct lcfs_node_s **nodep)
@@ -75,8 +76,22 @@ static void test_add_uninitialized_child(void)
 	assert(errno == EINVAL);
 }
 
+// Verifies that lcfs_fd_measure_fsverity fails on a fd without fsverity
+static void test_no_verity(void)
+{
+	char buf[] = "/tmp/test-verity.XXXXXX";
+	int tmpfd = mkstemp(buf);
+	assert(tmpfd > 0);
+
+	uint8_t digest[LCFS_DIGEST_SIZE];
+	int r = lcfs_fd_require_fsverity(digest, tmpfd);
+	assert(r != 0);
+	close(tmpfd);
+}
+
 int main(int argc, char **argv)
 {
 	test_basic();
+	test_no_verity();
 	test_add_uninitialized_child();
 }


### PR DESCRIPTION
lib: Add lcfs_fd_measure_fsverity

Our history with fsverity APIs is a bit messy. For now historical
reasons lcfs_fd_get_fsverity tries to query the kernel (via ioctl)
but will silently fall back to userspace computation - which
is sometimes desirable, other times not.

We also have lcfs_fd_compute_fsverity which is unconditionally
userspace.

However some cases actually really want to require the
fd to have fsverity - so add an API to do that.

Signed-off-by: Colin Walters <walters@verbum.org>

---

writer: Canonicalize no-verity errno to -ENOVERITY

This is what we do elsewhere.

Signed-off-by: Colin Walters <walters@verbum.org>

---

lib/mount: Use lcfs_fd_measure_fsverity

This is ensuring we have our fsverity ioctl parsing code in
one place.

Signed-off-by: Colin Walters <walters@verbum.org>

---

rust: Bind lcfs_fd_measure_fsverity

This is a reasonable thing to want to do.

Signed-off-by: Colin Walters <walters@verbum.org>

---