### PR TITLE
rust: Bind our default recommended max inline size

### DIFF
--- a/rust/composefs-sys/src/lib.rs
+++ b/rust/composefs-sys/src/lib.rs
@@ -1,7 +1,11 @@
 //! # Bindings for libcomposefs
 //!
 //! This crate contains a few manually maintained system bindings for libcomposefs.
+
+/// Size of a SHA-256 digest in bytes.
 pub const LCFS_SHA256_DIGEST_LEN: usize = 32;
+/// Recommended inline content size.
+pub const LCFS_RECOMMENDED_INLINE_CONTENT_MAX: u16 = 64;
 
 extern "C" {
     pub fn lcfs_compute_fsverity_from_fd(

--- a/rust/composefs/src/dumpfile.rs
+++ b/rust/composefs/src/dumpfile.rs
@@ -23,6 +23,9 @@ use libc::S_IFDIR;
 
 /// Maximum size accepted for inline content.
 const MAX_INLINE_CONTENT: u16 = 5000;
+/// The canonical default size to use for inline files.
+pub const RECOMMENDED_MAX_INLINE_CONTENT: u16 = composefs_sys::LCFS_RECOMMENDED_INLINE_CONTENT_MAX;
+
 /// https://github.com/torvalds/linux/blob/47ac09b91befbb6a235ab620c32af719f8208399/include/uapi/linux/limits.h#L15
 /// This isn't exposed in libc/rustix, and in any case we should be conservative...if this ever
 /// gets bumped it'd be a hazard.


### PR DESCRIPTION
It's quite important that this gets used consistently for interoperability - specifically, what would be really good is to ensure that going from "tar -> composefs" has a single well known digest. The choice of file inlining means different composefs projects can disagree on this.

Let's encourage this to be part of the composefs standard.