### PR TITLE
Do not enable man page generation when it is disabled.

### DIFF
--- a/composefs.spec.in
+++ b/composefs.spec.in
@@ -44,7 +44,11 @@ Library files for %{name}.
 %autosetup -p1
 
 %build
-%meson --default-library=shared -Dfuse=enabled -Dman=enabled 
+%if %{with man}
+%meson --default-library=shared -Dfuse=enabled -Dman=enabled
+%else
+%meson --default-library=shared -Dfuse=enabled -Dman=disabled
+%endif
 %meson_build
 
 %install


### PR DESCRIPTION
On arches like i686 the build of composefs fails because go-md2man is not available. The failure is caused by man page generation is enabled unconditionally.