### PR TITLE
writer: Fix return value of lcfs_node_unset_xattr

### DIFF
--- a/tests/test-lcfs.c
+++ b/tests/test-lcfs.c
@@ -58,6 +58,25 @@ static void test_basic(void)
 	assert(r == 0);
 }
 
+static void test_xattr_addremove(void)
+{
+	cleanup_node struct lcfs_node_s *node = lcfs_node_new();
+	lcfs_node_set_mode(node, S_IFDIR | 0755);
+	cleanup_node struct lcfs_node_s *child = lcfs_node_new();
+	lcfs_node_set_mode(child, S_IFDIR | 0700);
+	int r = lcfs_node_unset_xattr(child, "user.foo");
+	int errsv = errno;
+	assert(r == -1);
+	assert(errsv == ENODATA);
+	r = lcfs_node_set_xattr(child, "user.foo", "bar", 3);
+	assert(r == 0);
+	r = lcfs_node_unset_xattr(child, "user.foo");
+	assert(r == 0);
+	r = lcfs_node_add_child(node, child, "somechild");
+	assert(r == 0);
+	child = NULL;
+}
+
 static void test_add_uninitialized_child(void)
 {
 	cleanup_node struct lcfs_node_s *node = lcfs_node_new();
@@ -99,4 +118,5 @@ int main(int argc, char **argv)
 	test_basic();
 	test_no_verity();
 	test_add_uninitialized_child();
+	test_xattr_addremove();
 }


### PR DESCRIPTION
Since the first creation of this code in
5ac1f5c4 "lib: Update xattr APIs" this function
has always returned an error code - but nothing
checked it, so it didn't matter.

Now also, currently this function cannot fail
but let's give ourselves some flexibility here;
perhaps we want to e.g. invoke `realloc`
and in that case we'd need to handle OOM.

I just noticed this while working on commit
02077e89b5b81c76e962a6643c7a7423b1f8336f
to reject empty xattr names.

Change this to return success, and also check its
return value in the set path.