### PR TITLE
Add release binaries from git main on push

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -1,0 +1,55 @@
+name: Build binaries
+
+on: push
+
+permissions:
+  actions: read
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - baseimage: docker.io/library/ubuntu:24.04
+            basename: ubuntu-24.04
+          - baseimage: docker.io/library/ubuntu:22.04
+            basename: ubuntu-22.04
+          - baseimage: quay.io/fedora/fedora:41
+            basename: fedora-41
+          - baseimage: quay.io/centos/centos:stream9
+            basename: centos-stream9
+    runs-on: ubuntu-24.04
+    container: ${{ matrix.baseimage }}
+    steps:
+      - name: Bootstrap git
+        run: if test -x /usr/bin/apt; then apt -y update && apt -y install git; else dnf -y install git; fi
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Fix git perms
+        run: git config --global --add safe.directory $(pwd)
+      - name: Install dependencies
+        run: ./hacking/installdeps.sh
+      - name: Set environment
+        run: set -e
+             echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> $GITHUB_ENV
+      - name: Configure
+        run: meson setup build --prefix=/usr -Dfuse=disabled
+      - name: Build
+        run: meson compile -C build
+      - name: Capture build
+        run: set -e; DESTDIR=$(pwd)/instroot meson install -C build &&
+             tar -C instroot --sort=name --owner=0 --group=0 --numeric-owner
+               --mtime="${SOURCE_DATE_EPOCH}"
+               --pax-option=exthdr.name=%d/PaxHeaders/%f,delete=atime,delete=ctime
+               -czf composefs.tar.gz .
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: composefs-${{ matrix.basename }}.tar
+          path: composefs.tar.gz
+      - name: Upload log
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: testlog-asan.txt
+          path: build/meson-logs/testlog.txt

--- a/hacking/installdeps.sh
+++ b/hacking/installdeps.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 set -xeuo pipefail
+
+# Handle Fedora derivatives or others that have composefs
+# shipped already.
+
+if test -x /usr/bin/dnf; then
+    . /etc/os-release
+    case "${ID_LIKE:-}" in
+        *rhel*) dnf config-manager --set-enabled crb ;; 
+    esac
+    dnf -y install dnf-utils tar git meson;
+    dnf -y builddep composefs
+    exit 0
+fi
+
 export DEBIAN_FRONTEND=noninteractive
 
 PACKAGES=" \
@@ -9,6 +23,7 @@ PACKAGES=" \
     autotools-dev \
     git \
     make \
+    tar \
     gcc \
     libssl-dev \
     libfsverity-dev \
@@ -33,9 +48,11 @@ done
 
 # Install packages:
 if [ -n "${PACKAGES_REQUIRED}" ]; then
+    apt -y update
     apt-get install -y $PACKAGES_REQUIRED
 fi
 
 if [ -n "${PACKAGES_OPTIONAL}" ]; then
+    apt -y update
     apt-get install -y --ignore-missing $PACKAGES_OPTIONAL || true
 fi


### PR DESCRIPTION
Targeting a few distributions, produce a tarball with binaries.

This is intended to be used in other downstream CI scenarios.