### PR TITLE
mkcomposefs: Fix error message

### DIFF
--- a/tools/mkcomposefs.c
+++ b/tools/mkcomposefs.c
@@ -1669,7 +1669,7 @@ int main(int argc, char **argv)
 			err(EXIT_FAILURE, "error accessing %s", failed_path);
 
 		if (compute_digest(threads, root, src_path, buildflags) < 0)
-			err(EXIT_FAILURE, "error computing digest %s", failed_path);
+			err(EXIT_FAILURE, "error computing digest");
 
 		if (digest_store_path &&
 		    fill_store(threads, root, src_path, digest_store_path) < 0)


### PR DESCRIPTION
`failed_path` is declared here:

https://github.com/containers/composefs/blob/14ad6b9c8447dc57113028ffda65d9bfcb2c3cdd/tools/mkcomposefs.c#L1508

It looks like `failed_path` has not been set when it's used here:

https://github.com/containers/composefs/blob/14ad6b9c8447dc57113028ffda65d9bfcb2c3cdd/tools/mkcomposefs.c#L1672

An alternative fix is to use `src_path`. 
I just took the easiest alternative and removed the argument, but I can change that if you want.
