### PR TITLE
README: Link to composefs-rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,10 +175,9 @@ Mount options:
 
 ### Rust
 
-There are two Rust crates whose source code is included in this repository:
-
-- [rust/composefs-sys](composefs-sys): [![crates.io](https://img.shields.io/crates/v/composefs-sys)](https://crates.io/crates/composefs-sys) Low level unsafe `-sys` style wrapper library for linking to the `libcomposefs` C library.
-- [rust/composefs](composefs): [![crates.io](https://img.shields.io/crates/v/composefs)](https://crates.io/crates/composefs) Safe library that depends on `composefs-sys`, and also adds wrappers for invoking the external `mkfs.composefs` and `composefs-info dump` binaries.
+There is active work on a [composefs crate](https://github.com/containers/composefs-rs)
+which has both wrappers for invocations of the `mkcomposefs` and `composefs-info` dump tooling,
+as well as higher level repository functionality.
 
 ### Go
 


### PR DESCRIPTION
The in-tree crates are gone now.