### PR TITLE
Fix typos

### DIFF
--- a/man/composefs-dump.md
+++ b/man/composefs-dump.md
@@ -26,7 +26,7 @@ escape mechanism.
 
 Escapes are of the form \xXY which escapes a single byte using two hex
 digits. For example \x00 is the zero byte and \xff is the 255 byte.
-Optionally, these custom escapes are suppored:
+Optionally, these custom escapes are supported:
 
  **\\\\**
  :    backslash.

--- a/tools/mkcomposefs.c
+++ b/tools/mkcomposefs.c
@@ -1442,7 +1442,7 @@ static void usage(const char *argv0)
 		"  --print-digest-only   Print the digest of the image, don't write image\n"
 		"  --from-file           The source is a dump file, not a directory\n"
 		"  --min-version=N       Use this minimal format version (default=%d)\n"
-		"  --max-version=N       Use this maxium format version (default=%d)\n"
+		"  --max-version=N       Use this maximum format version (default=%d)\n"
 		"  --threads=N           Use this to override the default number of threads used to calculate digest and copy files (default=%d)\n",
 		bin, LCFS_DEFAULT_VERSION_MIN, LCFS_DEFAULT_VERSION_MAX,
 		get_cpu_count());


### PR DESCRIPTION
One typo in the composefs-dump manpage, one in the mkcomposefs help output.