### PR TITLE
composefs-info: Write 0 for directory sizes in dump output

### DIFF
--- a/man/composefs-dump.md
+++ b/man/composefs-dump.md
@@ -53,7 +53,8 @@ otherwise specified):
     line.
 
 **SIZE**
-:   The size of the file. This is ignored for directories.
+:   The size of the file. For directories this should be 0 (it is
+    ignored when reading).
 
 **MODE**
 :    The st_mode stat field the file in octal, which includes both the
@@ -105,9 +106,9 @@ After the fixed fields comes the xattrs, escaped and space-separated in the form
 # EXAMPLE
 
 ```
-/ 4096 40755 4 1000 1000 0 1695372970.944925700 - - - security.selinux=unconfined_u:object_r:unlabeled_t:s0\x00
-/a\x20dir\x20w\x20space 27 40755 2 1000 1000 0 1694598852.869646118 - - - security.selinux=unconfined_u:object_r:unlabeled_t:s0\x00
-/a-dir 45 40755 2 1000 1000 0 1674041780.601887980 - - - security.selinux=unconfined_u:object_r:unlabeled_t:s0\x00
+/ 0 40755 4 1000 1000 0 1695372970.944925700 - - - security.selinux=unconfined_u:object_r:unlabeled_t:s0\x00
+/a\x20dir\x20w\x20space 0 40755 2 1000 1000 0 1694598852.869646118 - - - security.selinux=unconfined_u:object_r:unlabeled_t:s0\x00
+/a-dir 0 40755 2 1000 1000 0 1674041780.601887980 - - - security.selinux=unconfined_u:object_r:unlabeled_t:s0\x00
 /a-dir/a-file 259 100644 1 1000 1000 0 1695368732.385062094 35/d02f81325122d77ec1d11baba655bc9bf8a891ab26119a41c50fa03ddfb408 - 35d02f81325122d77ec1d11baba655bc9bf8a891ab26119a41c50fa03ddfb408 security.selinux=unconfined_u:object_r:unlabeled_t:s0\x00
 /a-hardlink 259 @100644 1 1000 1000 0 1695368732.385062094 /a-dir/a-file - 35d02f81325122d77ec1d11baba655bc9bf8a891ab26119a41c50fa03ddfb408 security.selinux=unconfined_u:object_r:unlabeled_t:s0\x00
 /inline.txt 10 100644 1 1000 1000 0 1697019909.446146440 - some-text\n - security.selinux=unconfined_u:object_r:unlabeled_t:s0\x00

--- a/tests/test-dump-filtered.sh
+++ b/tests/test-dump-filtered.sh
@@ -15,7 +15,7 @@ foundlines=$(wc -l < $tmpd/dump.txt)
 if test "${foundlines}" != "4"; then
     fatal "Filtered dump failed, expected 4 lines, found $foundlines"
 fi
-assert_file_has_content $tmpd/dump.txt '^/ 4096 40555.*trusted.foo1'
+assert_file_has_content $tmpd/dump.txt '^/ 0 40555.*trusted.foo1'
 assert_file_has_content $tmpd/dump.txt '^/chardev 0 20777'
 assert_file_has_content $tmpd/dump.txt '^/inline 15 100777.*FOOBAR'
 assert_file_has_content $tmpd/dump.txt '^/whiteout 0 20777'

--- a/tools/composefs-info.c
+++ b/tools/composefs-info.c
@@ -194,11 +194,18 @@ static void dump_node(struct lcfs_node_s *node, char *path)
 	const char *payload = lcfs_node_get_payload(target);
 	const uint8_t *digest = lcfs_node_get_fsverity_digest(target);
 	const uint8_t *content = lcfs_node_get_content(target);
-	uint64_t size = lcfs_node_get_size(target);
+	uint32_t target_mode = lcfs_node_get_mode(target);
+	/* composefs-dump(5): "SIZE: The size of the file. This is ignored
+	 * for directories." Write 0 for directories so the dump output is
+	 * filesystem-independent (the on-disk directory size is an EROFS
+	 * implementation detail, not a meaningful filesystem property). */
+	uint64_t size = (target_mode & S_IFMT) == S_IFDIR
+				? 0
+				: lcfs_node_get_size(target);
 
 	print_escaped(*path == 0 ? "/" : path, -1, ESCAPE_STANDARD);
 	printf(" %" PRIu64 " %s%o %u %u %u %" PRIu64 " %" PRIi64 ".%u ", size,
-	       hardlink_path != NULL ? "@" : "", lcfs_node_get_mode(target),
+	       hardlink_path != NULL ? "@" : "", target_mode,
 	       lcfs_node_get_nlink(target), lcfs_node_get_uid(target),
 	       lcfs_node_get_gid(target), lcfs_node_get_rdev64(target),
 	       (int64_t)mtime.tv_sec, (unsigned int)mtime.tv_nsec);


### PR DESCRIPTION
composefs-dump(5) already specifies that the SIZE field "is ignored for directories", but composefs-info dump was writing the on-disk EROFS directory data size (e.g. the byte count of serialized erofs_dirent structures). This value is an EROFS implementation detail - POSIX just says st_size is implementation defined.

The motivation here is I want to have tests that round trip from composefs dumpfile -> EROFS -> dumpfile, and currently we discard the input size.

While we continue to ignore the size on dumpfile input, let's change our output to zero, and also suggest that 0 is provided as input.

Assisted-by: OpenCode (Claude Opus 4)