### PR TITLE
lcfs-writer-erofs: reject hardlinked whiteout inodes with EINVAL

### DIFF
--- a/libcomposefs/lcfs-writer-erofs.c
+++ b/libcomposefs/lcfs-writer-erofs.c
@@ -1766,7 +1766,17 @@ static struct lcfs_node_s *lcfs_build_node_from_image(struct lcfs_image_data *da
 	}
 
 	if (type == S_IFCHR && node->inode.st_rdev == 0) {
-		errno = ENOTSUP; /* Use this to signal that we found a whiteout */
+		/* A whiteout (chardev rdev=0) with nlink>1 is semantically
+		 * invalid: a whiteout represents the absence of a file, so it
+		 * cannot be hard-linked.  Reject the image explicitly rather
+		 * than silently skipping what would be a dangling alias. */
+		if (node->inode.st_nlink > 1) {
+			free(hash_remove(data->node_hash, &ht_entry));
+			errno = EINVAL;
+			return NULL;
+		}
+		free(hash_remove(data->node_hash, &ht_entry));
+		errno = ENOTSUP; /* Signal to caller: skip this whiteout entry */
 		return NULL;
 	}
 

--- a/tests/test-lcfs.c
+++ b/tests/test-lcfs.c
@@ -3,10 +3,14 @@
 
 #include "lcfs-writer.h"
 #include "lcfs-mount.h"
+#include "lcfs-erofs.h"
+#include "erofs_fs_wrapper.h"
 #include <string.h>
 #include <assert.h>
 #include <unistd.h>
 #include <errno.h>
+#include <endian.h>
+#include <sys/stat.h>
 
 static inline void lcfs_node_unrefp(struct lcfs_node_s **nodep)
 {
@@ -121,6 +125,108 @@ static void test_add_uninitialized_child(void)
 	assert(errno == EINVAL);
 }
 
+/* Regression test for heap-use-after-free when loading an EROFS image that
+ * contains a hardlinked whiteout (chardev with rdev=0, nlink>1).
+ *
+ * A whiteout represents the absence of a file, so nlink>1 is semantically
+ * invalid.  The loader must reject such images with EINVAL rather than
+ * silently processing them (which previously caused a use-after-free via a
+ * stale node_hash entry when the alias dirent appeared before the canonical
+ * one in the directory block).
+ *
+ * We construct a minimal EROFS image in memory rather than loading a binary
+ * fixture, so the test is self-contained.
+ */
+static void test_hardlinked_whiteout_load(void)
+{
+	/*
+	 * Image layout (2 blocks = 8192 bytes, all in block 0's metadata area):
+	 *
+	 *   0x000  lcfs_erofs_header_s        (composefs header, 32 bytes)
+	 *   0x400  erofs_super_block           (EROFS superblock, 128 bytes)
+	 *   0x480  erofs_inode_compact          root dir, nid=36, 32 bytes
+	 *   0x4A0  inline dir data             3 dirents + names, 41 bytes
+	 *   0x4E0  erofs_inode_compact          whiteout, nid=39, 32 bytes
+	 */
+	uint8_t image[2 * EROFS_BLKSIZ];
+	memset(image, 0, sizeof(image));
+
+	/* Composefs header at offset 0 */
+	struct lcfs_erofs_header_s *cfs = (struct lcfs_erofs_header_s *)image;
+	cfs->magic = htole32(LCFS_EROFS_MAGIC);
+	cfs->version = htole32(LCFS_EROFS_VERSION);
+
+	/* EROFS superblock at offset 1024 */
+	struct erofs_super_block *sb =
+		(struct erofs_super_block *)(image + EROFS_SUPER_OFFSET);
+	sb->magic = htole32(EROFS_SUPER_MAGIC_V1);
+	sb->blkszbits = EROFS_BLKSIZ_BITS;
+	sb->root_nid = htole16(36); /* nid=36 → offset 36*32 = 0x480 */
+	sb->inos = htole64(2);
+	sb->blocks = htole32(2);
+	sb->meta_blkaddr = htole32(0);
+	sb->xattr_blkaddr = htole32(0);
+
+	/* Root directory inode (compact, 32 bytes) at offset 0x480, nid=36.
+	 * Data layout = FLAT_INLINE (tailpacked dir entries follow the inode). */
+	const uint16_t root_nid = 36;
+	const uint16_t wh_nid = 39; /* offset 39*32 = 0x4E0 */
+	struct erofs_inode_compact *root_ino =
+		(struct erofs_inode_compact *)(image + root_nid * EROFS_SLOTSIZE);
+	root_ino->i_format =
+		htole16((EROFS_INODE_FLAT_INLINE << EROFS_I_DATALAYOUT_BIT) |
+			(EROFS_INODE_LAYOUT_COMPACT << EROFS_I_VERSION_BIT));
+	root_ino->i_mode = htole16(S_IFDIR | 0755);
+	root_ino->i_nlink = htole16(2);
+
+	/* Build inline directory data right after the root inode (offset 0x4A0).
+	 * 3 entries: "." (self), ".." (parent), "wh" (whiteout child).
+	 * Each dirent is 12 bytes; names start at offset 3*12 = 36. */
+	uint8_t *dir = image + root_nid * EROFS_SLOTSIZE +
+		       sizeof(struct erofs_inode_compact);
+	const uint16_t names_off = 3 * sizeof(struct erofs_dirent); /* 36 */
+	/* "." at offset 36, ".." at 37, "wh" at 39 → total = 41 bytes */
+	const uint32_t dir_size = names_off + 1 + 2 + 2; /* 41 */
+	root_ino->i_size = htole32(dir_size);
+
+	struct erofs_dirent *de = (struct erofs_dirent *)dir;
+	/* dirent[0]: "." */
+	de[0].nid = htole64(root_nid);
+	de[0].nameoff = htole16(names_off);
+	de[0].file_type = EROFS_FT_DIR;
+	/* dirent[1]: ".." */
+	de[1].nid = htole64(root_nid);
+	de[1].nameoff = htole16(names_off + 1);
+	de[1].file_type = EROFS_FT_DIR;
+	/* dirent[2]: "wh" */
+	de[2].nid = htole64(wh_nid);
+	de[2].nameoff = htole16(names_off + 3);
+	de[2].file_type = EROFS_FT_CHRDEV;
+
+	memcpy(dir + names_off, ".", 1);
+	memcpy(dir + names_off + 1, "..", 2);
+	memcpy(dir + names_off + 3, "wh", 2);
+
+	/* Whiteout inode (compact, 32 bytes) at offset 0x4E0, nid=39.
+	 * chardev with rdev=0 and nlink=252 (>1 triggers EINVAL). */
+	struct erofs_inode_compact *wh_ino =
+		(struct erofs_inode_compact *)(image + wh_nid * EROFS_SLOTSIZE);
+	wh_ino->i_format =
+		htole16((EROFS_INODE_FLAT_PLAIN << EROFS_I_DATALAYOUT_BIT) |
+			(EROFS_INODE_LAYOUT_COMPACT << EROFS_I_VERSION_BIT));
+	wh_ino->i_mode = htole16(S_IFCHR);
+	wh_ino->i_nlink = htole16(252);
+	wh_ino->i_u.rdev = htole32(0); /* rdev=0 makes it a whiteout */
+
+	/* The loader must reject this image with EINVAL (hardlinked whiteout)
+	 * and must not crash (the original bug was a use-after-free). */
+	cleanup_node struct lcfs_node_s *root =
+		lcfs_load_node_from_image(image, sizeof(image));
+	int errsv = errno;
+	assert(root == NULL);
+	assert(errsv == EINVAL);
+}
+
 // Verifies that lcfs_fd_measure_fsverity fails on a fd without fsverity
 static void test_no_verity(void)
 {
@@ -140,9 +246,13 @@ static void test_no_verity(void)
 
 int main(int argc, char **argv)
 {
+	(void)argc;
+	(void)argv;
+
 	test_basic();
 	test_no_verity();
 	test_add_uninitialized_child();
 	test_xattr_addremove();
 	test_xattr_doubleadd();
+	test_hardlinked_whiteout_load();
 }


### PR DESCRIPTION
A whiteout (chardev with rdev=0) represents the absence of a file, so it is semantically invalid for it to have nlink>1.

This was found via fuzzing in composefs-rs, currently we get a heap use-after-free when parsing such files.

Assisted-by: OpenCode (Claude Sonnet 4.6)